### PR TITLE
PR: Feature/m1

### DIFF
--- a/.github/workflows/tuvok.yml
+++ b/.github/workflows/tuvok.yml
@@ -20,10 +20,10 @@ jobs:
       - name: 📡 Initiate Transporter Lock (Checkout)
         uses: actions/checkout@v4
 
-      - name: 🧪 Load PNPM Protocols (pnpm 10.15.0)
+      - name: 🧪 Load PNPM Protocols (pnpm 10.33.0)
         uses: pnpm/action-setup@v4
         with:
-          version: 10.15.0
+          version: 10.33.0
 
       - name: 🖥️ Calibrate Starfleet Console (Node 22.18.x + pnpm cache)
         uses: actions/setup-node@v5

--- a/.github/workflows/tuvok.yml
+++ b/.github/workflows/tuvok.yml
@@ -40,5 +40,8 @@ jobs:
       - name: 🧭 Prime Directive Compliance (Lint CI)
         run: pnpm run lint:ci
 
-      - name: 🛡️ Holodeck Simulation (Unit Tests CI)
+      - name: 🧪 Core Validation – Unit Tests
         run: pnpm run test:unit:ci
+
+      - name: 🥒 Prime Directives – Acceptance Tests
+        run: pnpm run test:acceptance:ci

--- a/.github/workflows/tuvok.yml
+++ b/.github/workflows/tuvok.yml
@@ -40,6 +40,9 @@ jobs:
       - name: 🧭 Prime Directive Compliance (Lint CI)
         run: pnpm run lint:ci
 
+      - name: 🏗️ Core Assembly
+        run: pnpm run build
+
       - name: 🧪 Core Validation – Unit Tests
         run: pnpm run test:unit:ci
 

--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# AI files
+.codex
+
 # yarn v3
 .pnp.*
 .yarn/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,19 @@
 {
+  // Sichtbare Linien im Editor
+  "editor.rulers": [
+    {
+      "column": 80,
+      "color": "#ff990077"
+    },
+    100,
+    {
+      "column": 120,
+      "color": "#f50a0a4b"
+    }
+  ],
+
   // Formatierung & Linting
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
     "source.fixAll": "never",
     "source.fixAll.eslint": "explicit"
@@ -47,6 +59,8 @@
   // Cucumber-Auto-Complete
   "[feature]": {
     "editor.defaultFormatter": "alexkrechik.cucumberautocomplete",
+    "editor.formatOnSave": true,
+    "editor.formatOnType": true,
     "editor.tabSize": 2,
     "editor.insertSpaces": true
   },
@@ -60,6 +74,35 @@
   "cucumberautocomplete.stepsInvariants": true,
   "cucumberautocomplete.strictGherkinCompletion": true,
   "cucumberautocomplete.syncfeatures": "test/features/**/*.feature",
+  "cucumberautocomplete.formatConfOverride": {
+    "Feature:": 0,
+    "Funktionalität:": 0,
+    "Fähigkeit:": 0,
+    "Geschäftsbedarf:": 0,
+
+    "Szenario:": 1,
+    "Szenariogrundriss:": 1,
+    "Hintergrund:": 1,
+    "Grundlage:": 1,
+
+    "Beispiele:": 2,
+
+    "Angenommen": 2,
+    "Gegeben sei": 2,
+    "Gegeben seien": 2,
+    "Wenn": 2,
+    "Dann": 2,
+    "Und": 2,
+    "Aber": 2,
+    "*": 2,
+
+    "|": 4,
+    "\"\"\"": 4,
+
+    "#": "relative",
+    "@": "relative"
+  },
+  "cucumberautocomplete.gherkinDefinitionPart": "(Given|When|Then)\\(",
 
   // Todo Tree
   "todo-tree.highlights.defaultHighlight": {
@@ -124,5 +167,19 @@
     "[x]"
   ],
   "todo-tree.regex.regex": "(//|#|<!--|;|/\\*|^|^\\s*(-|\\d+.))\\s*($TAGS).*(\\n\\s*//\\s{2,}.*)*",
-  "cSpell.words": ["elif", "github", "janeway", "Starfleet", "Tuvok"]
+  "cSpell.words": [
+    "astrometrics",
+    "Astrometrics",
+    "dqat",
+    "Dqat",
+    "elif",
+    "github",
+    "holodeck",
+    "Holodeck",
+    "janeway",
+    "Logeinträge",
+    "Missionslog",
+    "Starfleet",
+    "Tuvok"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -173,13 +173,20 @@
     "dqat",
     "Dqat",
     "elif",
+    "gefreezte",
     "github",
     "holodeck",
     "Holodeck",
     "janeway",
     "Logeinträge",
     "Missionslog",
+    "Missionslogs",
+    "mutierbar",
+    "Prioritätsregeln",
+    "starfleet",
     "Starfleet",
-    "Tuvok"
+    "Szenarioende",
+    "Tuvok",
+    "unstub"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,6 +18,14 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
 
+  // JSON-Validierung
+  "json.schemas": [
+    {
+      "fileMatch": ["**/*.scene.json"],
+      "url": "./src/config/schema/holodeck.scene.v1.json"
+    }
+  ],
+
   // ESLint: Flat Config & validierte Sprachen
   "eslint.enable": true,
   "eslint.useFlatConfig": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -170,6 +170,7 @@
   "cSpell.words": [
     "astrometrics",
     "Astrometrics",
+    "Dmockserver",
     "dqat",
     "Dqat",
     "elif",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,18 @@
 # [1.0.0-alpha.2](https://github.com/RMajewski/dqat-core/compare/v1.0.0-alpha.1...v1.0.0-alpha.2) (2026-04-14)
 
-
 ### Bug Fixes
 
-* Janeway startet erst, wenn Tuvok grünes Licht gibt. ([15592c3](https://github.com/RMajewski/dqat-core/commit/15592c325efd086536a121255b6be830e8656340))
-* Janeway startet erst, wenn Tuvok grünes Licht gibt. ([12f8be9](https://github.com/RMajewski/dqat-core/commit/12f8be926246b97b969836136145bab8c25dc138))
-* Janeway trigger ([7dd2f88](https://github.com/RMajewski/dqat-core/commit/7dd2f888076c8a1b357f3d4a896615dfec9a6609))
-* Janeway-Action ([6c7d944](https://github.com/RMajewski/dqat-core/commit/6c7d944ceb718a317fbcfedab2e92f5d677fc13f))
-* **Setup:** Janeway benutzt richtig Commit. ([91ed1dc](https://github.com/RMajewski/dqat-core/commit/91ed1dc50374aff4c391327cf663fe56695db8fc))
-
+- Janeway startet erst, wenn Tuvok grünes Licht gibt. ([15592c3](https://github.com/RMajewski/dqat-core/commit/15592c325efd086536a121255b6be830e8656340))
+- Janeway startet erst, wenn Tuvok grünes Licht gibt. ([12f8be9](https://github.com/RMajewski/dqat-core/commit/12f8be926246b97b969836136145bab8c25dc138))
+- Janeway trigger ([7dd2f88](https://github.com/RMajewski/dqat-core/commit/7dd2f888076c8a1b357f3d4a896615dfec9a6609))
+- Janeway-Action ([6c7d944](https://github.com/RMajewski/dqat-core/commit/6c7d944ceb718a317fbcfedab2e92f5d677fc13f))
+- **Setup:** Janeway benutzt richtig Commit. ([91ed1dc](https://github.com/RMajewski/dqat-core/commit/91ed1dc50374aff4c391327cf663fe56695db8fc))
 
 ### Features
 
-* **astrometrics:** erste Iteration der Clock-Implementierung hinzugefügt ([838f210](https://github.com/RMajewski/dqat-core/commit/838f2100412cad96aa30423585b4f78ab0d53b4c))
-* **holodeck:** implementiere Engine-Adapter-Struktur und Integration in Holodeck ([c576242](https://github.com/RMajewski/dqat-core/commit/c576242ab3e0a755f5c8d1f43331662e7cbf2cb3)), closes [#7](https://github.com/RMajewski/dqat-core/issues/7)
-* **holodeck:** implementiere SceneLoader mit Template-Rendering und Schema-Validierung ([cf1aaad](https://github.com/RMajewski/dqat-core/commit/cf1aaaddc28065ad73e9266cab3d8c04e5a4a6a6))
+- **astrometrics:** erste Iteration der Clock-Implementierung hinzugefügt ([838f210](https://github.com/RMajewski/dqat-core/commit/838f2100412cad96aa30423585b4f78ab0d53b4c))
+- **holodeck:** implementiere Engine-Adapter-Struktur und Integration in Holodeck ([c576242](https://github.com/RMajewski/dqat-core/commit/c576242ab3e0a755f5c8d1f43331662e7cbf2cb3)), closes [#7](https://github.com/RMajewski/dqat-core/issues/7)
+- **holodeck:** implementiere SceneLoader mit Template-Rendering und Schema-Validierung ([cf1aaad](https://github.com/RMajewski/dqat-core/commit/cf1aaaddc28065ad73e9266cab3d8c04e5a4a6a6))
 
 # 1.0.0-alpha.1 (2025-10-03)
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ import typescriptEslintPlugin from '@typescript-eslint/eslint-plugin';
 import typescriptEslintParser from '@typescript-eslint/parser';
 import eslintConfigPrettier from 'eslint-config-prettier';
 import importPlugin from 'eslint-plugin-import';
+import jsonSchemaValidator from 'eslint-plugin-json-schema-validator';
 import prettier from 'eslint-plugin-prettier';
 import sonarjs from 'eslint-plugin-sonarjs';
 
@@ -240,6 +241,28 @@ export default [
         'warn',
         {
           prefer: 'no-type-imports',
+        },
+      ],
+    },
+  },
+
+  // JSON-Schema-Validation
+  ...jsonSchemaValidator.configs.recommended,
+  {
+    files: ['**/*.scene.json'],
+    plugins: {
+      'json-schema-validator': jsonSchemaValidator,
+    },
+    rules: {
+      'json-schema-validator/no-invalid': [
+        'error',
+        {
+          schemas: [
+            {
+              fileMatch: ['**/*.scene.json'],
+              schema: './src/config/schema/holodeck.scene.v1.json',
+            },
+          ],
         },
       ],
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "packageManager": "pnpm@10.15.0",
   "engines": {
-    "node": "^22.18.0"
+    "node": ">=22.18 <24",
+    "pnpm": ">=10 <11"
   },
   "repository": {
     "type": "git",
@@ -127,6 +128,11 @@
       "import": "./dist/step/index.js",
       "types": "./dist/step/index.d.ts",
       "require": "./dist/step/index.cjs"
+    },
+    "./utils": {
+      "import": "./dist/util/index.js",
+      "types": "./dist/util/index.d.ts",
+      "require": "./dist/util/index.cjs"
     }
   },
   "typesVersions": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-json-schema-validator": "^6.2.0",
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-sonarjs": "^3.0.5",
     "husky": "^9.1.7",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "rene.majewski@gmx.de",
     "url": "https://www.rene-majewski.de"
   },
-  "packageManager": "pnpm@10.15.0",
+  "packageManager": "pnpm@10.33.0",
   "engines": {
     "node": ">=22.18 <24",
     "pnpm": ">=10 <11"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "test:acceptance:wip": "npm run test:acceptance -- --tags \"@Wip\"",
     "test:acceptance:dry": "cucumber-js --config test/acceptance/cucumber.config.cjs --dry-run",
     "test:acceptance:report": "cucumber-js --config test/acceptance/cucumber.config.cjs --format html:test/reports/cucumber/index.html",
+    "test:acceptance:ci": "npm run test:acceptance -- -p ci",
     "typecheck:test": "tsc -p tsconfig.test.json --noEmit"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       eslint-plugin-import:
         specifier: ^2.32.0
         version: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.36.0)
+      eslint-plugin-json-schema-validator:
+        specifier: ^6.2.0
+        version: 6.2.0(eslint@9.36.0)
       eslint-plugin-prettier:
         specifier: ^5.5.4
         version: 5.5.4(eslint-config-prettier@10.1.8(eslint@9.36.0))(eslint@9.36.0)(prettier@3.6.2)
@@ -1470,6 +1473,17 @@ packages:
       eslint-plugin-import-x:
         optional: true
 
+  eslint-json-compat-utils@0.2.3:
+    resolution: {integrity: sha512-RbBmDFyu7FqnjE8F0ZxPNzx5UaptdeS9Uu50r7A+D7s/+FCX+ybiyViYEgFUaFIFqSWJgZRTpL5d8Kanxxl2lQ==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      '@eslint/json': '*'
+      eslint: '*'
+      jsonc-eslint-parser: ^2.4.0 || ^3.0.0
+    peerDependenciesMeta:
+      '@eslint/json':
+        optional: true
+
   eslint-module-utils@2.12.1:
     resolution: {integrity: sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==}
     engines: {node: '>=4'}
@@ -1501,6 +1515,12 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
+  eslint-plugin-json-schema-validator@6.2.0:
+    resolution: {integrity: sha512-jHdo7MwJm94Z0lhlBtwa2dtRKBgiJNk3d5HGeyjhHszmlnCXsEu3blTjGWO0tzWg04UANoygB10CaRYcTBZCsg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: '>=9.38.0'
+
   eslint-plugin-prettier@5.5.4:
     resolution: {integrity: sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -1531,6 +1551,10 @@ packages:
   eslint-visitor-keys@4.2.1:
     resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   eslint@9.36.0:
     resolution: {integrity: sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==}
@@ -2168,6 +2192,10 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-migrate-x@2.1.0:
+    resolution: {integrity: sha512-idC5B/FLaEsMydSW+I302kEmg9RecqsdG12nAfmgp9SmrqDzmea9wTlE56rQlV3P3cWY6AAcA8/By4gyCQES/A==}
+    engines: {node: '>=0.10.0'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -2180,6 +2208,10 @@ packages:
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
+
+  jsonc-eslint-parser@3.1.0:
+    resolution: {integrity: sha512-75EA7EWZExL/j+MDKQrRbdzcRI2HOkRlmUw8fZJc1ioqFEOvBsq7Rt+A6yCxOt9w/TYNpkt52gC6nm/g5tFIng==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
@@ -3214,6 +3246,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toml-eslint-parser@1.0.3:
+    resolution: {integrity: sha512-A5F0cM6+mDleacLIEUkmfpkBbnHJFV1d2rprHU2MXNk7mlxHq2zGojA+SRvQD1RoMo9gqjZPWEaKG4v1BQ48lw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   toposort@2.0.2:
     resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
 
@@ -3270,6 +3306,9 @@ packages:
     resolution: {integrity: sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -3540,6 +3579,10 @@ packages:
     resolution: {integrity: sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==}
     engines: {node: '>=0.10.32'}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
+  yaml-eslint-parser@2.0.0:
+    resolution: {integrity: sha512-h0uDm97wvT2bokfwwTmY6kJ1hp6YDFL0nRHwNKz8s/VD1FH/vvZjAKoMUE+un0eaYBSG7/c6h+lJTP+31tjgTw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   yaml@2.8.1:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
@@ -5042,6 +5085,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-json-compat-utils@0.2.3(eslint@9.36.0)(jsonc-eslint-parser@3.1.0):
+    dependencies:
+      eslint: 9.36.0
+      esquery: 1.6.0
+      jsonc-eslint-parser: 3.1.0
+
   eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.36.0):
     dependencies:
       debug: 3.2.7
@@ -5082,6 +5131,24 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
+  eslint-plugin-json-schema-validator@6.2.0(eslint@9.36.0):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0)
+      ajv: 8.17.1
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 9.36.0
+      eslint-json-compat-utils: 0.2.3(eslint@9.36.0)(jsonc-eslint-parser@3.1.0)
+      json-schema-migrate-x: 2.1.0
+      jsonc-eslint-parser: 3.1.0
+      minimatch: 10.0.3
+      synckit: 0.11.11
+      toml-eslint-parser: 1.0.3
+      tunnel-agent: 0.6.0
+      yaml-eslint-parser: 2.0.0
+    transitivePeerDependencies:
+      - '@eslint/json'
+      - supports-color
+
   eslint-plugin-prettier@5.5.4(eslint-config-prettier@10.1.8(eslint@9.36.0))(eslint@9.36.0)(prettier@3.6.2):
     dependencies:
       eslint: 9.36.0
@@ -5113,6 +5180,8 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint-visitor-keys@5.0.1: {}
 
   eslint@9.36.0:
     dependencies:
@@ -5788,6 +5857,10 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-migrate-x@2.1.0:
+    dependencies:
+      ajv: 8.17.1
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -5797,6 +5870,12 @@ snapshots:
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
+
+  jsonc-eslint-parser@3.1.0:
+    dependencies:
+      acorn: 8.15.0
+      eslint-visitor-keys: 5.0.1
+      semver: 7.7.2
 
   jsonfile@6.2.0:
     dependencies:
@@ -6798,6 +6877,10 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toml-eslint-parser@1.0.3:
+    dependencies:
+      eslint-visitor-keys: 5.0.1
+
   toposort@2.0.2: {}
 
   tr46@1.0.1:
@@ -6859,6 +6942,10 @@ snapshots:
       get-tsconfig: 4.10.1
     optionalDependencies:
       fsevents: 2.3.3
+
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.1.2
 
   type-check@0.4.0:
     dependencies:
@@ -7170,6 +7257,11 @@ snapshots:
   y18n@5.0.8: {}
 
   yaeti@0.0.6: {}
+
+  yaml-eslint-parser@2.0.0:
+    dependencies:
+      eslint-visitor-keys: 5.0.1
+      yaml: 2.8.1
 
   yaml@2.8.1: {}
 

--- a/src/callback/directive.ts
+++ b/src/callback/directive.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert';
+import type { DqatWorld } from '../setup/DqatWorld.ts';
+
+/**
+ * Prüft, ob ein Starfleet-Directive-Key auf den erwarteten String-Wert aufgelöst wird.
+ *
+ * Dieser Callback eignet sich für exportierte Cucumber-Step-Definitionen,
+ * wenn das Verhalten der geladenen Starfleet Directives überprüft werden soll,
+ * ohne Aussagen über die interne Provider-Reihenfolge direkt in den Step-Text
+ * zu kodieren.
+ *
+ * @example
+ * ```feature
+ * Dann sollte der Starfleet Directive Key "path" den Wert "env" haben
+ * ```
+ *
+ * @param key Zu prüfender Directive-Key
+ * @param expectedValue Erwarteter Wert
+ */
+export function assertDirectiveHasValueCallback(
+  this: DqatWorld,
+  key: string,
+  expectedValue: string,
+): void {
+  const actualValue = this.getStarfleetDirectives().resolveDirective(key);
+
+  assert.notStrictEqual(
+    actualValue,
+    undefined,
+    `Für den Starfleet Directive Key "${key}" wurde kein Wert gefunden.`,
+  );
+
+  assert.strictEqual(
+    actualValue,
+    expectedValue,
+    `Der Starfleet Directive Key "${key}" hat nicht den erwarteten Wert.`,
+  );
+}

--- a/src/callback/endpoint.ts
+++ b/src/callback/endpoint.ts
@@ -1,0 +1,138 @@
+// src/callback/endpoint.ts
+
+import type { DqatWorld } from '../setup/DqatWorld.ts';
+import type { HttpResponseSnapshot } from '../type/httpResponse.ts';
+
+/**
+ * Führt einen HTTP-Request aus und speichert das Ergebnis (Statuscode,
+ * Header, Body-Text) in `this.lastResponse`.
+ *
+ * Diese Funktion ist bewusst NICHT an Holodeck gekoppelt.
+ * Sie funktioniert für jede erreichbare URL, z. B.:
+ * - den vom Holodeck bereitgestellten MockServer,
+ * - ein echtes Staging-Backend,
+ * - einen lokalen Dev-Server.
+ *
+ * URL-Auflösung:
+ *
+ * 1. Wenn `pathOrUrl` bereits mit "http://" oder "https://" beginnt,
+ *    wird dieser Wert direkt als vollständige URL verwendet.
+ *
+ * 2. Andernfalls:
+ *    - Es wird versucht, eine Basis-URL über `this.get<string>('basisUrl')`
+ *      zu beziehen.
+ *      Beispiel: "http://localhost:1080"
+ *
+ *    - Falls keine Basis-URL konfiguriert ist, wird ein Error geworfen.
+ *
+ *    - Die endgültige URL ergibt sich dann aus:
+ *         <basisUrl><pathOrUrl>
+ *
+ * Typischer Gherkin-Schritt:
+ *
+ *   Wenn ich den Endpunkt "/api/status" über GET abrufe
+ *
+ * oder alternativ mit absoluter Adresse:
+ *
+ *   Wenn ich den Endpunkt "https://api.example.test/health" über GET abrufe
+ *
+ * @example
+ * Gherkin (Feature-Datei, deutsch):
+ *   Wenn ich den Endpunkt "/api/status" über GET abrufe
+ *
+ * @param this DqatWorld – Gemeinsamer Szenario-Kontext.
+ * @param method string – HTTP-Methode wie "GET", "POST", "PATCH", "DELETE".
+ * @param pathOrUrl string – Entweder ein relativer Pfad (z. B. "/api/status")
+ *                           oder bereits eine vollständige URL
+ *                           (z. B. "https://api.example.test/health").
+ */
+export async function fetchRequestCallback(
+  this: DqatWorld,
+  pathOrUrl: string,
+  method: string,
+): Promise<void> {
+  // Schritt 1: finale URL bestimmen
+  let finalUrl: string;
+
+  const looksAbsolute =
+    pathOrUrl.startsWith('http://') || pathOrUrl.startsWith('https://');
+
+  if (looksAbsolute) {
+    finalUrl = pathOrUrl;
+  } else {
+    const baseUrl = this.get('basisUrl') as string;
+    console.debug('baseUrl', { baseUrl });
+    if (!baseUrl) {
+      throw new Error(
+        `Es wurde keine Basis-URL gefunden (Schlüssel "basisUrl"), und der Pfad "${pathOrUrl}" ist nicht absolut.`,
+      );
+    }
+    finalUrl = `${baseUrl}${pathOrUrl}`;
+  }
+
+  // Schritt 2: Request senden
+  // TODO: Echte Implementierung mit fetch(finalUrl, { method })
+  // const response = await fetch(finalUrl, { method });
+  // const bodyText = await response.text();
+  //
+  // const headers: Record<string, string> = {};
+  // response.headers.forEach((value, key) => {
+  //   headers[key.toLowerCase()] = value;
+  // });
+  //
+  // const snapshot: HttpResponseSnapshot = {
+  //   status: response.status,
+  //   headers,
+  //   bodyText,
+  // };
+  //
+  // this.lastResponse = snapshot;
+
+  // Platzhalter, bis die echte HTTP-Logik integriert wird:
+  const snapshot: HttpResponseSnapshot = {
+    status: 200,
+    headers: {
+      'content-type': 'application/json',
+      'x-dqat-debug-url': finalUrl,
+      'x-dqat-debug-method': method,
+    },
+    bodyText: '{"ok":true}',
+  };
+
+  this.lastResponse = snapshot;
+}
+
+/**
+ * Prüft, dass der Statuscode der zuletzt gespeicherten HTTP-Antwort
+ * (`this.lastResponse`) dem erwarteten Wert entspricht.
+ *
+ * Wenn der erwartete Status nicht übereinstimmt, wird ein Fehler geworfen,
+ * wodurch das Cucumber-Szenario fehlschlägt.
+ *
+ * Typischer Gherkin-Schritt:
+ *
+ *   Dann erwarte ich den HTTP-Statuscode 200
+ *
+ * @example
+ * Gherkin (Feature-Datei, deutsch):
+ *   Dann erwarte ich den HTTP-Statuscode 200
+ *
+ * @param this DqatWorld – Gemeinsamer Szenario-Kontext.
+ * @param expectedStatus number – Erwarteter HTTP-Statuscode (z. B. 200, 404, 500).
+ */
+export function expectLastResponseStatusCallback(
+  this: DqatWorld,
+  expectedStatus: number,
+): void {
+  if (!this.lastResponse) {
+    throw new Error(
+      'Es liegt keine letzte Response vor, die geprüft werden kann.',
+    );
+  }
+
+  if (this.lastResponse.status !== expectedStatus) {
+    throw new Error(
+      `Unerwarteter Statuscode: erwartet ${expectedStatus}, aber erhalten ${this.lastResponse.status}`,
+    );
+  }
+}

--- a/src/callback/endpoint.ts
+++ b/src/callback/endpoint.ts
@@ -60,7 +60,7 @@ export async function fetchRequestCallback(
   if (looksAbsolute) {
     finalUrl = pathOrUrl;
   } else {
-    const baseUrl = this.get('basisUrl') as string;
+    const baseUrl = this.get<string>('baseUrl');
     console.debug('baseUrl', { baseUrl });
     if (!baseUrl) {
       throw new Error(
@@ -71,32 +71,18 @@ export async function fetchRequestCallback(
   }
 
   // Schritt 2: Request senden
-  // TODO: Echte Implementierung mit fetch(finalUrl, { method })
-  // const response = await fetch(finalUrl, { method });
-  // const bodyText = await response.text();
-  //
-  // const headers: Record<string, string> = {};
-  // response.headers.forEach((value, key) => {
-  //   headers[key.toLowerCase()] = value;
-  // });
-  //
-  // const snapshot: HttpResponseSnapshot = {
-  //   status: response.status,
-  //   headers,
-  //   bodyText,
-  // };
-  //
-  // this.lastResponse = snapshot;
+  const response = await fetch(finalUrl, { method });
+  const bodyText = await response.text();
 
-  // Platzhalter, bis die echte HTTP-Logik integriert wird:
+  const headers: Record<string, string> = {};
+  response.headers.forEach((value, key) => {
+    headers[key.toLowerCase()] = value;
+  });
+
   const snapshot: HttpResponseSnapshot = {
-    status: 200,
-    headers: {
-      'content-type': 'application/json',
-      'x-dqat-debug-url': finalUrl,
-      'x-dqat-debug-method': method,
-    },
-    bodyText: '{"ok":true}',
+    status: response.status,
+    headers,
+    bodyText,
   };
 
   this.lastResponse = snapshot;

--- a/src/callback/holodeck.ts
+++ b/src/callback/holodeck.ts
@@ -7,6 +7,7 @@ import { SceneLoader } from '../holodeck/sceneLoader.ts';
 import type { DqatWorld } from '../setup/DqatWorld.ts';
 import { HolodeckSceneLoadErrorCode } from '../type/holodeck/holodeck.error.ts';
 import type { HolodeckSceneDocument } from '../type/holodeck/sceneDocument.ts';
+import { shutdownHolodeckWithLogs } from '../util/holodeck/shutdown.ts';
 
 /**
  * Startet das Holodeck im gewünschten Modus (z. B. "embedded" oder "remote").
@@ -176,12 +177,7 @@ export async function loadSceneCallback(
  * @param this DqatWorld – Gemeinsamer Szenario-Kontext.
  */
 export async function stopHolodeckCallback(this: DqatWorld): Promise<void> {
-  if (!this.holodeck) {
-    return;
-  }
-
-  await this.holodeck.stop();
-  this.holodeck = undefined;
+  await shutdownHolodeckWithLogs(this);
 }
 
 /**

--- a/src/callback/holodeck.ts
+++ b/src/callback/holodeck.ts
@@ -1,4 +1,12 @@
+import Ajv2020 from 'ajv/dist/2020.js';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { HolodeckSceneLoadError } from '../holodeck/holodeck.error.ts';
+import { Holodeck } from '../holodeck/holodeck.ts';
+import { SceneLoader } from '../holodeck/sceneLoader.ts';
 import type { DqatWorld } from '../setup/DqatWorld.ts';
+import { HolodeckSceneLoadErrorCode } from '../type/holodeck/holodeck.error.ts';
+import type { HolodeckSceneDocument } from '../type/holodeck/sceneDocument.ts';
 
 /**
  * Startet das Holodeck im gewünschten Modus (z. B. "embedded" oder "remote").
@@ -29,40 +37,83 @@ export async function startHolodeckCallback(
   this: DqatWorld,
   mode: 'embedded' | 'remote',
 ): Promise<void> {
-  // TODO:
-  // - Holodeck-Instanz anhand der Konfiguration erstellen
-  //   (host, port, forbidProd, sceneLoader, mode).
-  // - this.holodeck = new Holodeck(config);
-  //
-  // - Holodeck starten:
-  //   const startResult = await this.holodeck.start();
-  //
-  // - Optional: Mission-Log-Eintrag schreiben mit startResult.baseUrl usw.
-  //
-  // Noch keine konkrete Implementierung hier, damit wir später sauber
-  // injizieren können (SceneLoader etc.).
   if (mode !== 'embedded' && mode !== 'remote') {
     throw new Error(
       `Unbekannter Holodeck-Modus "${mode}". Erlaubt sind nur "embedded" und "remote".`,
     );
   }
 
-  /*
+  if (this.holodeck) {
+    await this.holodeck.stop();
+    this.holodeck = undefined;
+  }
+
+  const fixturesDir =
+    this.get<string>('holodeck.fixturesDir') ??
+    path.resolve(process.cwd(), 'test/acceptance/fixtures/holodeck');
+
+  const sceneLoader = new SceneLoader({
+    readSceneDocumentByName: async (
+      sceneName: string,
+    ): Promise<HolodeckSceneDocument> => {
+      const sceneFilePath = path.join(fixturesDir, `${sceneName}.scene.json`);
+
+      let documentText: string;
+      try {
+        documentText = await readFile(sceneFilePath, 'utf8');
+      } catch (error) {
+        const isMissingFile =
+          typeof error === 'object' &&
+          error !== null &&
+          'code' in error &&
+          (error as { code?: string }).code === 'ENOENT';
+
+        if (isMissingFile) {
+          throw new HolodeckSceneLoadError({
+            code: HolodeckSceneLoadErrorCode.UNKNOWN_SCENE,
+            message: `Scene "${sceneName}" not found in ${fixturesDir}`,
+            path: 'scene',
+          });
+        }
+        throw error;
+      }
+
+      try {
+        return JSON.parse(documentText) as HolodeckSceneDocument;
+      } catch {
+        throw new HolodeckSceneLoadError({
+          code: HolodeckSceneLoadErrorCode.SCHEMA_VIOLATION,
+          message: `Scene "${sceneName}" contains invalid JSON`,
+          path: sceneFilePath,
+        });
+      }
+    },
+    nowProvider: () => this.now(),
+    ajvInstance: new Ajv2020({
+      allErrors: true,
+      strict: true,
+      allowUnionTypes: true,
+      coerceTypes: false,
+    }),
+  });
+
   const holodeck = new Holodeck({
     host: 'localhost',
     port: 1080,
     mode,
     forbidProd: true,
-    sceneLoader:
+    sceneLoader,
   });
 
   const startResult = await holodeck.start();
   this.holodeck = holodeck;
+  this.set('baseUrl', startResult.baseUrl);
 
-  if (mode === 'embedded') {
-    this.set('baseUrl', startResult.baseUrl);
-  }
-  */
+  this.log('info', 'holodeck started', {
+    mode,
+    baseUrl: startResult.baseUrl,
+    fixturesDir,
+  });
 }
 
 /**
@@ -91,12 +142,15 @@ export async function loadSceneCallback(
   this: DqatWorld,
   sceneName: string,
 ): Promise<void> {
-  // TODO:
-  // - Safety-Check: if (!this.holodeck) throw new Error("Holodeck ist nicht gestartet.");
-  // - await this.holodeck.loadScene(sceneName, {});
-  //
-  // Kein persistenter Scene-Handle in der World nötig, solange du ihn
-  // nicht für spätere Auswertung brauchst.
+  if (!this.holodeck) {
+    throw new Error(
+      'Das Holodeck ist nicht gestartet. Starte es vor dem Laden einer Szene.',
+    );
+  }
+
+  const sceneHandle = await this.holodeck.loadScene(sceneName, {});
+  this.set('holodeck.sceneHandle', sceneHandle);
+  this.log('info', 'holodeck scene loaded', { sceneName, sceneHandle });
 }
 
 /**

--- a/src/callback/holodeck.ts
+++ b/src/callback/holodeck.ts
@@ -1,0 +1,152 @@
+import type { DqatWorld } from '../setup/DqatWorld.ts';
+
+/**
+ * Startet das Holodeck im gewünschten Modus (z. B. "embedded" oder "remote").
+ *
+ * Diese Funktion erzeugt bzw. initialisiert eine Holodeck-Instanz und ruft
+ * deren `start()`-Methode auf.
+ *
+ * Wichtig:
+ * - Der zurückgelieferte Wert von `holodeck.start()` (z. B. baseUrl)
+ *   wird hier nicht dauerhaft irgendwo gespeichert. Der typische Anwendungsfall
+ *   ist, daraus einen Mission-Log-Eintrag für den Report zu erzeugen.
+ * - Falls schon ein Holodeck aktiv ist, sollte es idealerweise vorher sauber
+ *   gestoppt werden. Diese Schutzlogik kann später ergänzt werden.
+ *
+ * Typischer Gherkin-Schritt:
+ *
+ *   Angenommen das Holodeck wurde im Modus "embedded" gestartet
+ *
+ * @example
+ * Gherkin (Feature-Datei, deutsch):
+ *   Angenommen das Holodeck wurde im Modus "embedded" gestartet
+ *
+ * @param this DqatWorld – Gemeinsamer Szenario-Kontext.
+ * @param mode "embedded" | "remote" – Steuerung, ob das Holodeck selbst einen
+ *             MockServer-Prozess hochfahren soll oder sich nur verbindet.
+ */
+export async function startHolodeckCallback(
+  this: DqatWorld,
+  mode: 'embedded' | 'remote',
+): Promise<void> {
+  // TODO:
+  // - Holodeck-Instanz anhand der Konfiguration erstellen
+  //   (host, port, forbidProd, sceneLoader, mode).
+  // - this.holodeck = new Holodeck(config);
+  //
+  // - Holodeck starten:
+  //   const startResult = await this.holodeck.start();
+  //
+  // - Optional: Mission-Log-Eintrag schreiben mit startResult.baseUrl usw.
+  //
+  // Noch keine konkrete Implementierung hier, damit wir später sauber
+  // injizieren können (SceneLoader etc.).
+  if (mode !== 'embedded' && mode !== 'remote') {
+    throw new Error(
+      `Unbekannter Holodeck-Modus "${mode}". Erlaubt sind nur "embedded" und "remote".`,
+    );
+  }
+
+  /*
+  const holodeck = new Holodeck({
+    host: 'localhost',
+    port: 1080,
+    mode,
+    forbidProd: true,
+    sceneLoader:
+  });
+
+  const startResult = await holodeck.start();
+  this.holodeck = holodeck;
+
+  if (mode === 'embedded') {
+    this.set('baseUrl', startResult.baseUrl);
+  }
+  */
+}
+
+/**
+ * Lädt eine Szene in das laufende Holodeck.
+ *
+ * Die Szene beschreibt vorbereitete Routen / Responses, die über den
+ * MockServer bereitgestellt werden. Nach dem Laden der Szene sind
+ * nachfolgende Requests (z. B. über fetchRequestCallback) deterministisch
+ * reproduzierbar.
+ *
+ * Voraussetzung:
+ * - Das Holodeck muss bereits gestartet worden sein.
+ *
+ * Typischer Gherkin-Schritt:
+ *
+ *   Wenn die Holodeck-Szene "happy" geladen wird
+ *
+ * @example
+ * Gherkin (Feature-Datei, deutsch):
+ *   Wenn die Holodeck-Szene "happy" geladen wird
+ *
+ * @param this DqatWorld – Gemeinsamer Szenario-Kontext.
+ * @param sceneName string – Logischer Szenen-Name, z. B. "happy".
+ */
+export async function loadSceneCallback(
+  this: DqatWorld,
+  sceneName: string,
+): Promise<void> {
+  // TODO:
+  // - Safety-Check: if (!this.holodeck) throw new Error("Holodeck ist nicht gestartet.");
+  // - await this.holodeck.loadScene(sceneName, {});
+  //
+  // Kein persistenter Scene-Handle in der World nötig, solange du ihn
+  // nicht für spätere Auswertung brauchst.
+}
+
+/**
+ * Stoppt das aktuell laufende Holodeck.
+ *
+ * Dieser Schritt ist für Aufräum-Prozesse gedacht und soll idempotent sein:
+ * - Wenn kein Holodeck aktiv ist, passiert einfach nichts.
+ * - Wenn ein Holodeck aktiv ist, wird dessen `stop()` aufgerufen
+ *   und anschließend die Referenz entfernt.
+ *
+ * Typischer Gherkin-Schritt:
+ *
+ *   Wenn das Holodeck gestoppt wird
+ *
+ * oder als Validierungsschritt:
+ *
+ *   Dann ist kein Holodeck mehr aktiv
+ *
+ * @example
+ * Gherkin (Feature-Datei, deutsch):
+ *   Wenn das Holodeck gestoppt wird
+ *
+ * @param this DqatWorld – Gemeinsamer Szenario-Kontext.
+ */
+export async function stopHolodeckCallback(this: DqatWorld): Promise<void> {
+  if (!this.holodeck) {
+    return;
+  }
+
+  await this.holodeck.stop();
+  this.holodeck = undefined;
+}
+
+/**
+ * Prüft, dass aktuell kein Holodeck in der World registriert ist.
+ *
+ * Dieser Callback ist bewusst klein gehalten, damit die fachliche Aussage
+ * direkt im Gherkin lesbar bleibt und die eigentliche Prüf-Logik nicht
+ * inline in der Step-Definition steht.
+ *
+ * @example
+ * Gherkin (Feature-Datei, deutsch):
+ *   Dann ist kein Holodeck mehr aktiv
+ *
+ * @param this DqatWorld – Gemeinsamer Szenario-Kontext.
+ */
+export function expectNoActiveHolodeckCallback(this: DqatWorld): void {
+  if (this.holodeck) {
+    throw new Error(
+      'Es ist noch ein Holodeck aktiv, obwohl keines aktiv sein sollte.',
+    );
+  }
+}

--- a/src/callback/index.ts
+++ b/src/callback/index.ts
@@ -1,4 +1,5 @@
 export * from './clock.ts';
+export * from './directive.ts';
 export * from './endpoint.ts';
 export * from './holodeck.ts';
 export * from './mission-log.ts';

--- a/src/callback/index.ts
+++ b/src/callback/index.ts
@@ -1,3 +1,5 @@
 export * from './clock.ts';
+export * from './endpoint.ts';
+export * from './holodeck.ts';
 export * from './mission-log.ts';
 export * from './world.ts';

--- a/src/config/starfleetDirectives.config.ts
+++ b/src/config/starfleetDirectives.config.ts
@@ -1,4 +1,32 @@
 /**
+ * @file StarfleetDirectives – zentrale Framework-Konfiguration
+ *
+ * Diese Datei definiert:
+ * 1. Standard-Pfadangaben der DQAT-Konfigurationsdateien (Reihenfolge wichtig!)
+ * 2. Provider-Defaults, die von den jeweiligen Provider-Konstruktoren genutzt werden.
+ *
+ * Hinweis:
+ * - Diese Datei darf beliebig angepasst werden, z. B. um weitere
+ *   Konfigurationsdateien aufzunehmen oder Standards zu ändern.
+ * - Die Werte werden **nicht** direkt verändert; Provider rufen intern ihre
+ *   normalize-Funktionen auf, um fehlende Felder zu ergänzen.
+ */
+
+/**
+ * In dieser Reihenfolge werden Konfigurations-Dateien geprüft und geladen.
+ * Nur existierende Dateien werden berücksichtigt.
+ *
+ * Die Reihenfolge entspricht gleichzeitig der Priorität:
+ * - Früher geladene Dateien liefern Basiskonfigurationen
+ * - Später geladene Dateien überschreiben Werte früherer
+ */
+export const STARFLEET_DIRECTIVE_CONFIG_FILES = [
+  './dqat.config.json',
+  './test/dqat.config.json',
+  './test/acceptance/dqat.config.json',
+] as const;
+
+/**
  * Standard-Trennzeichen für verschachtelte Schlüssel.
  * Beispiel: "database.host" → Trenner "."
  */

--- a/src/config/starfleetDirectives.keys.ts
+++ b/src/config/starfleetDirectives.keys.ts
@@ -1,0 +1,112 @@
+/**
+ * @file starfleetDirectiveKey.ts
+ * @description Zentrale Schlüsseldefinitionen für interne Framework-Directives.
+ *
+ * Diese Datei stellt Konstanten für alle im Framework verwendeten Konfigurations-
+ * und Provider-Keys bereit. Durch die Verwendung dieser Konstanten anstelle
+ * von String-Literalen werden Tippfehler vermieden und Umbenennungen vereinfacht.
+ */
+
+import type { IEnvProviderOptions } from '../type/provider/providerOptions.ts';
+
+/**
+ * Sammlung aller derzeit definierten Starfleet-Directive-Schlüssel.
+ *
+ * Jeder Eintrag repräsentiert einen logischen Konfigurations- oder
+ * Framework-Parameter, der innerhalb von JSON-, ENV- oder Memory-Providern
+ * vorkommen kann.
+ *
+ * Diese Konstanten sollten in allen Komponenten verwendet werden,
+ * anstatt die Schlüssel als String-Literals zu wiederholen.
+ */
+export const StarfleetDirectiveKey = {
+  /**
+   * Schlüsselname für die ENV-Provider-Optionen innerhalb einer
+   * JSON-Konfigurationsdatei.
+   *
+   * Wird im Loader genutzt, um aus der ersten gefundenen
+   * DQAT-Konfiguration (z. B. `./test/acceptance/dqat.config.json`)
+   * die gewünschten Optionen für den EnvProvider zu extrahieren.
+   *
+   * Beispiel (in JSON-Datei):
+   * ```json
+   * {
+   *   "envProviderOptions": {
+   *     "stripPrefix": "DQ_",
+   *     "toLowerCase": true
+   *   }
+   * }
+   * ```
+   */
+  envProviderOptions: 'envProviderOptions',
+
+  /**
+   * Reservierter Schlüssel für zukünftige Framework-weite
+   * Einstellungen, z. B. Logging- oder Versionierungsparameter.
+   *
+   * Dieser Schlüssel wird aktuell nicht aktiv genutzt,
+   * dient aber als Vorlage für künftige Erweiterungen.
+   *
+   * Beispiel:
+   * ```json
+   * {
+   *   "framework.settings": {
+   *     "logLevel": "debug"
+   *   }
+   * }
+   * ```
+   */
+  frameworkSettings: 'framework.settings',
+} as const;
+
+/**
+ * Union-Typ aller bekannten Starfleet-Directive-Schlüssel.
+ *
+ * Dieser Typ kann für generische Methoden verwendet werden,
+ * um Parameter wie `key: TStarfleetDirectiveKey`
+ * typsicher zu beschränken.
+ */
+export type TStarfleetDirectiveKey =
+  (typeof StarfleetDirectiveKey)[keyof typeof StarfleetDirectiveKey];
+
+/**
+ * @interface IStarfleetDirectiveSchema
+ * @description
+ * Definiert die erwarteten Rückgabe-Typen für alle aktuell bekannten
+ * Starfleet-Directive-Schlüssel, die in {@link StarfleetDirectiveKey}
+ * definiert sind.
+ *
+ * Dieses Interface stellt sicher, dass Aufrufe wie
+ * `world.getDirective(StarfleetDirectiveKey.envProviderOptions)`
+ * stets den richtigen Typ liefern und Tippfehler in Schlüssel-Namen
+ * frühzeitig erkannt werden.
+ */
+export interface IStarfleetDirectiveSchema {
+  /**
+   * Optionen für den Env-Provider, die aus einer JSON-Konfigurationsdatei
+   * gelesen werden können.
+   *
+   * Typischerweise definiert in `dqat.config.json` oder einer der
+   * Test-spezifischen Varianten (z. B. `./test/acceptance/dqat.config.json`).
+   *
+   * Beispiel:
+   * ```json
+   * {
+   *   "envProviderOptions": {
+   *     "stripPrefix": "DQ_",
+   *     "toLowerCase": true
+   *   }
+   * }
+   * ```
+   */
+  [StarfleetDirectiveKey.envProviderOptions]: IEnvProviderOptions;
+
+  /**
+   * Platzhalter für Framework-weite Einstellungen oder Metadaten,
+   * die künftig für Logging-, Diagnose- oder Versionszwecke genutzt
+   * werden können.
+   *
+   * Aktuell reserviert und noch nicht aktiv verwendet.
+   */
+  [StarfleetDirectiveKey.frameworkSettings]: Record<string, unknown>;
+}

--- a/src/factory/provider/envProvider.ts
+++ b/src/factory/provider/envProvider.ts
@@ -1,8 +1,8 @@
 import type {
-  EnvProviderOptions,
+  IEnvProviderOptions,
   NormalizedEnvOptions,
 } from '../../type/provider/providerOptions.ts';
-import type { StarfleetDirectiveProvider } from '../../type/starfleetDirective.ts';
+import type { IStarfleetDirectiveProvider } from '../../type/starfleetDirective.ts';
 import {
   applyStripPrefix,
   mapDoubleUnderscoreToSeparator,
@@ -24,7 +24,7 @@ import {
  * - `get(key)`
  * - `list(prefix?)`
  */
-export class EnvProvider implements StarfleetDirectiveProvider {
+export class EnvProvider implements IStarfleetDirectiveProvider {
   /** Logischer Name des Providers (für Logs/Debugging). */
   public readonly name: string;
 
@@ -38,7 +38,7 @@ export class EnvProvider implements StarfleetDirectiveProvider {
    */
   public constructor(
     env: Record<string, string | undefined>,
-    inputOptions?: EnvProviderOptions,
+    inputOptions?: IEnvProviderOptions,
   ) {
     this.options = normalizeEnvOptions(inputOptions ?? {});
     this.name = this.options.name ?? 'env';

--- a/src/factory/provider/envProvider.ts
+++ b/src/factory/provider/envProvider.ts
@@ -2,7 +2,7 @@ import type {
   IEnvProviderOptions,
   NormalizedEnvOptions,
 } from '../../type/provider/providerOptions.ts';
-import type { IStarfleetDirectiveProvider } from '../../type/starfleetDirective.ts';
+import type { StarfleetDirectiveProvider } from '../../type/starfleetDirective.ts';
 import {
   applyStripPrefix,
   mapDoubleUnderscoreToSeparator,
@@ -24,7 +24,7 @@ import {
  * - `get(key)`
  * - `list(prefix?)`
  */
-export class EnvProvider implements IStarfleetDirectiveProvider {
+export class EnvProvider implements StarfleetDirectiveProvider {
   /** Logischer Name des Providers (für Logs/Debugging). */
   public readonly name: string;
 

--- a/src/factory/provider/jsonFileProvider.ts
+++ b/src/factory/provider/jsonFileProvider.ts
@@ -4,7 +4,7 @@ import type {
   IJsonFileProviderOptions,
   NormalizedJsonFileOptions,
 } from '../../type/provider/providerOptions.ts';
-import type { IStarfleetDirectiveProvider } from '../../type/starfleetDirective.ts';
+import type { StarfleetDirectiveProvider } from '../../type/starfleetDirective.ts';
 import { flattenObject } from '../../util/provider/flatten.ts';
 import { isPlainObject } from '../../util/provider/guards.ts';
 import { normalizeJsonFileOptions } from '../../util/provider/optionNormalization.ts';
@@ -17,7 +17,7 @@ import { normalizeJsonFileOptions } from '../../util/provider/optionNormalizatio
  * - `get(key)`
  * - `list(prefix?)`
  */
-export class JsonFileProvider implements IStarfleetDirectiveProvider {
+export class JsonFileProvider implements StarfleetDirectiveProvider {
   public readonly name: string;
 
   private readonly options: NormalizedJsonFileOptions;

--- a/src/factory/provider/jsonFileProvider.ts
+++ b/src/factory/provider/jsonFileProvider.ts
@@ -1,10 +1,10 @@
 import fs from 'node:fs';
 import path, { isAbsolute } from 'node:path';
 import type {
-  JsonFileProviderOptions,
+  IJsonFileProviderOptions,
   NormalizedJsonFileOptions,
 } from '../../type/provider/providerOptions.ts';
-import type { StarfleetDirectiveProvider } from '../../type/starfleetDirective.ts';
+import type { IStarfleetDirectiveProvider } from '../../type/starfleetDirective.ts';
 import { flattenObject } from '../../util/provider/flatten.ts';
 import { isPlainObject } from '../../util/provider/guards.ts';
 import { normalizeJsonFileOptions } from '../../util/provider/optionNormalization.ts';
@@ -17,14 +17,17 @@ import { normalizeJsonFileOptions } from '../../util/provider/optionNormalizatio
  * - `get(key)`
  * - `list(prefix?)`
  */
-export class JsonFileProvider implements StarfleetDirectiveProvider {
+export class JsonFileProvider implements IStarfleetDirectiveProvider {
   public readonly name: string;
 
   private readonly options: NormalizedJsonFileOptions;
   private readonly filePath: string;
   private readonly flatData: Record<string, unknown>;
 
-  public constructor(fileName: string, inputOptions?: JsonFileProviderOptions) {
+  public constructor(
+    fileName: string,
+    inputOptions?: IJsonFileProviderOptions,
+  ) {
     this.options = normalizeJsonFileOptions(inputOptions ?? {});
     this.name = this.options.name ?? 'json';
 

--- a/src/factory/provider/memoryProvider.ts
+++ b/src/factory/provider/memoryProvider.ts
@@ -1,8 +1,8 @@
 import type {
-  MemoryProviderOptions,
+  IMemoryProviderOptions,
   NormalizedMemoryOptions,
 } from '../../type/provider/providerOptions.ts';
-import type { StarfleetDirectiveProvider } from '../../type/starfleetDirective.ts';
+import type { IStarfleetDirectiveProvider } from '../../type/starfleetDirective.ts';
 import { flattenObject } from '../../util/provider/flatten.ts';
 import { normalizeMemoryOptions } from '../../util/provider/optionNormalization.ts';
 
@@ -14,7 +14,7 @@ import { normalizeMemoryOptions } from '../../util/provider/optionNormalization.
  * - `get(key)`
  * - `list(prefix?)`
  */
-export class MemoryProvider implements StarfleetDirectiveProvider {
+export class MemoryProvider implements IStarfleetDirectiveProvider {
   /** Logischer Name des Providers (für Logs/Debugging). */
   public readonly name: string;
 
@@ -27,13 +27,13 @@ export class MemoryProvider implements StarfleetDirectiveProvider {
    */
   constructor(
     input: Record<string, unknown>,
-    inputOptions?: MemoryProviderOptions,
+    inputOptions?: IMemoryProviderOptions,
   );
   constructor(
     input: string | number | boolean | null | undefined,
-    inputOptions?: MemoryProviderOptions,
+    inputOptions?: IMemoryProviderOptions,
   );
-  constructor(input: unknown, inputOptions: MemoryProviderOptions = {}) {
+  constructor(input: unknown, inputOptions: IMemoryProviderOptions = {}) {
     this.options = normalizeMemoryOptions(inputOptions ?? {});
     this.name = this.options.name ?? 'memory';
 

--- a/src/factory/provider/memoryProvider.ts
+++ b/src/factory/provider/memoryProvider.ts
@@ -2,7 +2,7 @@ import type {
   IMemoryProviderOptions,
   NormalizedMemoryOptions,
 } from '../../type/provider/providerOptions.ts';
-import type { IStarfleetDirectiveProvider } from '../../type/starfleetDirective.ts';
+import type { StarfleetDirectiveProvider } from '../../type/starfleetDirective.ts';
 import { flattenObject } from '../../util/provider/flatten.ts';
 import { normalizeMemoryOptions } from '../../util/provider/optionNormalization.ts';
 
@@ -14,7 +14,7 @@ import { normalizeMemoryOptions } from '../../util/provider/optionNormalization.
  * - `get(key)`
  * - `list(prefix?)`
  */
-export class MemoryProvider implements IStarfleetDirectiveProvider {
+export class MemoryProvider implements StarfleetDirectiveProvider {
   /** Logischer Name des Providers (für Logs/Debugging). */
   public readonly name: string;
 
@@ -81,6 +81,28 @@ export class MemoryProvider implements IStarfleetDirectiveProvider {
       }
     }
     return out;
+  }
+
+  /**
+   * Setzt oder überschreibt einen einzelnen Wert im In-Memory-Speicher.
+   *
+   * Verhalten:
+   * - Funktionswerte werden nicht gespeichert.
+   * - `undefined` wird bei aktivem `dropUndefined` entfernt.
+   * - In allen anderen Fällen wird der Wert direkt unter dem exakten Key gespeichert.
+   */
+  public set(key: string, value: unknown): void {
+    if (typeof value === 'function') {
+      delete this.flatData[key];
+      return;
+    }
+
+    if (value === undefined && this.options.dropUndefined) {
+      delete this.flatData[key];
+      return;
+    }
+
+    this.flatData[key] = value;
   }
 
   /** Aktive Optionen (Debug/Tests). */

--- a/src/factory/starfleetDirective.ts
+++ b/src/factory/starfleetDirective.ts
@@ -1,6 +1,6 @@
 import type {
-  IStarfleetDirectiveProvider,
-  IStarfleetDirectives,
+  StarfleetDirectiveProvider,
+  StarfleetDirectives,
   StarfleetDirectivesOptions,
 } from '../type/starfleetDirective.ts';
 
@@ -14,9 +14,9 @@ import type {
  * - **JSON-safe**: Funktionen werden unterdrückt; komplexe Werte werden sicher geklont.
  */
 export function createStarfleetDirectives(
-  providers: readonly IStarfleetDirectiveProvider[],
+  providers: readonly StarfleetDirectiveProvider[],
   opts: StarfleetDirectivesOptions = {},
-): IStarfleetDirectives {
+): StarfleetDirectives {
   const preferFirst = opts.preferFirst ?? true;
   const doFreeze = opts.freeze ?? true;
 

--- a/src/factory/starfleetDirective.ts
+++ b/src/factory/starfleetDirective.ts
@@ -70,6 +70,15 @@ export function createStarfleetDirectives(
     names.add(p.name);
   }
 
+  const hasProvider = (providerName: string): boolean => {
+    for (const name of names) {
+      if (name.indexOf(providerName) >= 0) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   // --- Kern-Helfer ---------------------------------------------------------
 
   const findValue = (key: string): unknown | undefined => {
@@ -135,5 +144,5 @@ export function createStarfleetDirectives(
     return deepFreeze(cloneSafe(out));
   };
 
-  return { resolveDirective, hasDirective, listDirectives };
+  return { resolveDirective, hasDirective, listDirectives, hasProvider };
 }

--- a/src/factory/starfleetDirective.ts
+++ b/src/factory/starfleetDirective.ts
@@ -1,6 +1,6 @@
 import type {
-  StarfleetDirectiveProvider,
-  StarfleetDirectives,
+  IStarfleetDirectiveProvider,
+  IStarfleetDirectives,
   StarfleetDirectivesOptions,
 } from '../type/starfleetDirective.ts';
 
@@ -14,9 +14,9 @@ import type {
  * - **JSON-safe**: Funktionen werden unterdrückt; komplexe Werte werden sicher geklont.
  */
 export function createStarfleetDirectives(
-  providers: readonly StarfleetDirectiveProvider[],
+  providers: readonly IStarfleetDirectiveProvider[],
   opts: StarfleetDirectivesOptions = {},
-): StarfleetDirectives {
+): IStarfleetDirectives {
   const preferFirst = opts.preferFirst ?? true;
   const doFreeze = opts.freeze ?? true;
 

--- a/src/holodeck/engine/adapterBase.ts
+++ b/src/holodeck/engine/adapterBase.ts
@@ -129,4 +129,23 @@ export abstract class HolodeckEngineAdapterBase {
       totalRequests: routes.length,
     };
   }
+
+  /**
+   * Liefert die aktuell vom MockServer aufgezeichneten Log-Nachrichten.
+   *
+   * Die zurückgegebenen Logs enthalten interne Debug-Informationen des
+   * MockServers, wie z. B. Matching-Entscheidungen, eingehende Requests
+   * sowie generierte Responses – abhängig vom konfigurierten Log-Level.
+   *
+   * Die Methode greift ausschließlich lesend auf die Logs zu und verändert
+   * den Zustand des MockServers nicht. Insbesondere werden die Logs nicht
+   * automatisch geleert.
+   *
+   * Typischer Anwendungsfall ist das Schreiben der Logs in eine Report-Datei
+   * (z. B. pro Szenario), um die Konsolenausgabe sauber zu halten und dennoch
+   * vollständige Debug-Informationen verfügbar zu haben.
+   */
+  public async retrieveLogMessages(): Promise<string[]> {
+    return await this.client.retrieveLogMessages({});
+  }
 }

--- a/src/holodeck/engine/embeddedEngineAdapter.ts
+++ b/src/holodeck/engine/embeddedEngineAdapter.ts
@@ -12,8 +12,12 @@ export class HolodeckEmbeddedEngineAdapter extends HolodeckEngineAdapterBase {
   public async start(): Promise<void> {
     await mockserver.start_mockserver({
       serverPort: this.port,
+      // TODO Zur Konfiguration hinzufügen
       verbose: true,
+      // TODO Zur Konfiguration hinzufügen
       trace: true,
+      // TODO Zur Konfiguration hinzufügen
+      jvmOptions: ['-Dmockserver.disableSystemOut=true'],
     });
   }
 

--- a/src/holodeck/holodeck.ts
+++ b/src/holodeck/holodeck.ts
@@ -118,6 +118,7 @@ export class Holodeck {
    */
   public async start(): Promise<HolodeckStartResult> {
     // TODO: forbidProd-Check einbauen (z. B. NODE_ENV === 'production' verbieten)
+    this.forbidProd;
     await this.adapter.start();
     this.hasStarted = true;
 

--- a/src/holodeck/holodeck.ts
+++ b/src/holodeck/holodeck.ts
@@ -213,4 +213,23 @@ export class Holodeck {
 
     return this.adapter.introspect();
   }
+
+  /**
+   * Liefert die aktuell vom MockServer aufgezeichneten Log-Nachrichten.
+   *
+   * Die zurückgegebenen Logs enthalten interne Debug-Informationen des
+   * MockServers, wie z. B. Matching-Entscheidungen, eingehende Requests
+   * sowie generierte Responses – abhängig vom konfigurierten Log-Level.
+   *
+   * Die Methode greift ausschließlich lesend auf die Logs zu und verändert
+   * den Zustand des MockServers nicht. Insbesondere werden die Logs nicht
+   * automatisch geleert.
+   *
+   * Typischer Anwendungsfall ist das Schreiben der Logs in eine Report-Datei
+   * (z. B. pro Szenario), um die Konsolenausgabe sauber zu halten und dennoch
+   * vollständige Debug-Informationen verfügbar zu haben.
+   */
+  public async retrieveLogMessages(): Promise<string[]> {
+    return this.adapter.retrieveLogMessages();
+  }
 }

--- a/src/setup/DqatWorld.ts
+++ b/src/setup/DqatWorld.ts
@@ -11,6 +11,7 @@ import type {
   MissionLogLevel,
 } from '../type/astrometrics/missionLog.ts';
 import type { HttpResponseSnapshot } from '../type/httpResponse.ts';
+import type { IEnvProviderOptions } from '../type/provider/providerOptions.ts';
 import type { StarfleetDirectives } from '../type/starfleetDirective.ts';
 import { loadStarfleetDirectives } from './loadStarfleetDirectives.ts';
 
@@ -57,6 +58,19 @@ export class DqatWorld implements ICucumberWorld {
    * Hinweis: Wir halten die konkrete Klasse, damit `set` verfügbar ist.
    */
   private memoryProvider?: MemoryProvider;
+
+  /**
+   * Effektiv verwendete Optionen für den Env-Provider innerhalb dieses Szenarios.
+   *
+   * Dieses Feld wird beim Initialisieren der DqatWorld aus dem Ergebnis von
+   * `loadStarfleetDirectives` übernommen und repräsentiert die final aufgelösten
+   * ENV-Provider-Einstellungen (inkl. Defaults und Normalisierung).
+   *
+   * Es dient ausschließlich der internen Verwendung innerhalb der World und
+   * wird nicht direkt nach außen exponiert, um unbeabsichtigte Mutationen zu
+   * verhindern.
+   */
+  private envProviderOptions?: IEnvProviderOptions;
 
   /**
    * Liefert die aktuelle Zeit der World.
@@ -208,7 +222,7 @@ export class DqatWorld implements ICucumberWorld {
    * Lädt JSON-, ENV- und Memory-Provider gemäß Prioritätsregeln.
    */
   public loadStarfleetDirectives(additionalPaths: string[]): void {
-    const { starfleetDirectives, memoryProvider } =
+    const { starfleetDirectives, memoryProvider, envProviderOptions } =
       loadStarfleetDirectives(additionalPaths);
 
     // Konkreten Memory-Provider sicherstellen (für set-Operationen)
@@ -222,5 +236,23 @@ export class DqatWorld implements ICucumberWorld {
 
     this.directives = starfleetDirectives;
     this.memoryProvider = memoryProvider;
+    this.envProviderOptions = envProviderOptions;
+  }
+
+  /**
+   * Liefert die effektiv verwendeten Optionen des Env-Providers.
+   *
+   * Diese Methode stellt die während des Ladevorgangs ermittelten und
+   * normalisierten ENV-Provider-Optionen zur Verfügung. Sie eignet sich
+   * insbesondere für Debugging-Zwecke sowie für Akzeptanztests, die prüfen,
+   * ob Konfigurationswerte korrekt übernommen wurden.
+   *
+   * Die zurückgegebenen Optionen sind schreibgeschützt und entsprechen dem
+   * Zustand zum Zeitpunkt der Initialisierung der DqatWorld.
+   *
+   * @returns Die final aufgelösten ENV-Provider-Optionen dieses Szenarios.
+   */
+  public getEnvProviderOptions(): IEnvProviderOptions | undefined {
+    return this.envProviderOptions;
   }
 }

--- a/src/setup/DqatWorld.ts
+++ b/src/setup/DqatWorld.ts
@@ -1,10 +1,18 @@
-import type { IWorldOptions } from '@cucumber/cucumber';
 import type { Astrometrics } from '../astrometrics/astrometrics.ts';
+import type {
+  IStarfleetDirectiveSchema,
+  TStarfleetDirectiveKey,
+} from '../config/starfleetDirectives.keys.ts';
+import { MemoryProvider } from '../factory/provider/memoryProvider.ts';
+import type { Holodeck } from '../holodeck/holodeck.ts';
 import type { ICucumberWorld } from '../type/ICucumberWorld.ts';
 import type {
   MissionLogEntry,
   MissionLogLevel,
 } from '../type/astrometrics/missionLog.ts';
+import type { HttpResponseSnapshot } from '../type/httpResponse.ts';
+import type { IStarfleetDirectives } from '../type/starfleetDirective.ts';
+import { loadStarfleetDirectives } from './loadStarfleetDirectives.ts';
 
 /**
  * DQAT-World (Iteration 1 – ohne Astrometrics-Implementierung)
@@ -21,6 +29,8 @@ import type {
  */
 export class DqatWorld implements ICucumberWorld {
   public astrometrics?: Astrometrics;
+  public holodeck?: Holodeck;
+  public lastResponse?: HttpResponseSnapshot;
 
   /**
    * Szenario-lokaler Key-Value-Speicher
@@ -37,7 +47,16 @@ export class DqatWorld implements ICucumberWorld {
    */
   private disposerStack: Array<() => void | Promise<void>> = [];
 
-  constructor(_options: IWorldOptions) {}
+  /**
+   * Schreibgeschützte Directives-Instanz (liefert gefreezte Werte).
+   */
+  private directives?: IStarfleetDirectives;
+
+  /**
+   * Konkreter Memory-Provider (mutierbar, höchste Priorität).
+   * Hinweis: Wir halten die konkrete Klasse, damit `set` verfügbar ist.
+   */
+  private memoryProvider?: MemoryProvider;
 
   /**
    * Liefert die aktuelle Zeit der World.
@@ -126,5 +145,80 @@ export class DqatWorld implements ICucumberWorld {
 
   public getMissionLogBuffer(): MissionLogEntry[] {
     return this.missionLogBuffer;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public getStarfleetDirectives(): IStarfleetDirectives {
+    if (!this.directives) {
+      throw new Error('Keine StarfleetDirectives geladen');
+    }
+    return this.directives;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public getDirective<K extends TStarfleetDirectiveKey>(
+    key: K,
+  ): IStarfleetDirectiveSchema[K] | undefined {
+    if (!this.directives) {
+      throw new Error('Keine StarfleetDirectives geladen');
+    }
+    return this.directives.resolveDirective<IStarfleetDirectiveSchema[K]>(key);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public hasDirective(key: TStarfleetDirectiveKey): boolean {
+    if (!this.directives) {
+      throw new Error('Keine StarfleetDirectives geladen');
+    }
+    return this.directives.hasDirective(key);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public listDirectives(prefix?: string): Readonly<Record<string, unknown>> {
+    if (!this.directives) {
+      throw new Error('Keine StarfleetDirectives geladen');
+    }
+    return this.directives.listDirectives(prefix);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public setDirectiveOverride<K extends TStarfleetDirectiveKey>(
+    key: K,
+    value: IStarfleetDirectiveSchema[K],
+  ): void {
+    // TODO MemoryProvider.set implementieren.
+    this.memoryProvider;
+    throw new Error('Method not implemented yet.');
+  }
+
+  /**
+   * Erstellt eine neue World-Instanz für ein einzelnes Szenario.
+   * Lädt JSON-, ENV- und Memory-Provider gemäß Prioritätsregeln.
+   */
+  public loadStarfleetDirectives(additionalPaths: string[]): void {
+    const { starfleetDirectives, memoryProvider } =
+      loadStarfleetDirectives(additionalPaths);
+
+    // Konkreten Memory-Provider sicherstellen (für set-Operationen)
+    if (!(memoryProvider instanceof MemoryProvider)) {
+      // Falls dein Loader zukünftig ein anderes Konstrukt liefert,
+      // ist dies ein expliziter, frühzeitiger Hinweis.
+      throw new Error(
+        'DqatWorld: Erwarteter MemoryProvider ist keine Instanz von MemoryProvider.',
+      );
+    }
+
+    this.directives = starfleetDirectives;
+    this.memoryProvider = memoryProvider;
   }
 }

--- a/src/setup/DqatWorld.ts
+++ b/src/setup/DqatWorld.ts
@@ -11,7 +11,7 @@ import type {
   MissionLogLevel,
 } from '../type/astrometrics/missionLog.ts';
 import type { HttpResponseSnapshot } from '../type/httpResponse.ts';
-import type { IStarfleetDirectives } from '../type/starfleetDirective.ts';
+import type { StarfleetDirectives } from '../type/starfleetDirective.ts';
 import { loadStarfleetDirectives } from './loadStarfleetDirectives.ts';
 
 /**
@@ -50,7 +50,7 @@ export class DqatWorld implements ICucumberWorld {
   /**
    * Schreibgeschützte Directives-Instanz (liefert gefreezte Werte).
    */
-  private directives?: IStarfleetDirectives;
+  private directives?: StarfleetDirectives;
 
   /**
    * Konkreter Memory-Provider (mutierbar, höchste Priorität).
@@ -76,7 +76,7 @@ export class DqatWorld implements ICucumberWorld {
   };
 
   /**
-   * Liest einen Wert aus dem szenario-lokalen Store.
+   * Liest einen Wert aus dem Szenario-lokalen Store.
    *
    * @returns T | undefined, wenn Schlüssel nicht gesetzt ist
    */
@@ -85,7 +85,7 @@ export class DqatWorld implements ICucumberWorld {
   }
 
   /**
-   * Schreibt einen Wert in den szenario-lokalen Store (überschreibt vorhandene Werte).
+   * Schreibt einen Wert in den Szenario-lokalen Store (überschreibt vorhandene Werte).
    */
   public set<T = unknown>(key: string, value: T): void {
     this.runtimeStore.set(key, value);
@@ -150,7 +150,7 @@ export class DqatWorld implements ICucumberWorld {
   /**
    * @inheritdoc
    */
-  public getStarfleetDirectives(): IStarfleetDirectives {
+  public getStarfleetDirectives(): StarfleetDirectives {
     if (!this.directives) {
       throw new Error('Keine StarfleetDirectives geladen');
     }
@@ -196,9 +196,11 @@ export class DqatWorld implements ICucumberWorld {
     key: K,
     value: IStarfleetDirectiveSchema[K],
   ): void {
-    // TODO MemoryProvider.set implementieren.
-    this.memoryProvider;
-    throw new Error('Method not implemented yet.');
+    if (!this.memoryProvider) {
+      throw new Error('Es ist kein Memory-Provider initialisiert.');
+    }
+
+    this.memoryProvider.set(key, value);
   }
 
   /**

--- a/src/setup/hooks/after.ts
+++ b/src/setup/hooks/after.ts
@@ -1,5 +1,6 @@
 import type { ITestCaseHookParameter } from '@cucumber/cucumber';
 import { After } from '@cucumber/cucumber';
+import { shutdownHolodeckWithLogs } from '../../util/holodeck/shutdown.ts';
 import type { DqatWorld } from '../DqatWorld.ts';
 
 /**
@@ -17,6 +18,8 @@ export function afterHookGeneral(): void {
       correlation: { runId, scenarioId },
       result: { status: scenario.result?.status },
     });
+
+    await shutdownHolodeckWithLogs(this);
 
     await this.disposeAll();
   });

--- a/src/setup/hooks/before.ts
+++ b/src/setup/hooks/before.ts
@@ -22,6 +22,9 @@ export function beforeScenarioGeneral(): void {
 
     this.set('run.id', runId);
     this.set('scenario.id', scenarioId);
+    this.set('scenario.cucumberScenarioId', scenario.pickle.id);
+    this.set('scenario.name', scenario.pickle.name);
+    this.set('scenario.language', scenario.pickle.language);
     this.set('effectiveDirectives', effectiveDirectives);
     this.set('tags', tagNames);
 

--- a/src/setup/loadStarfleetDirectives.ts
+++ b/src/setup/loadStarfleetDirectives.ts
@@ -49,7 +49,6 @@ export function loadStarfleetDirectives(
     ...additionalPaths,
   ];
   for (const relativePath of paths) {
-    console.debug(`read the "${relativePath} config file`);
     const absolutePath = resolve(process.cwd(), relativePath);
     if (!existsSync(absolutePath)) {
       continue;
@@ -62,12 +61,9 @@ export function loadStarfleetDirectives(
     jsonProviders.push(jsonFileProvider);
 
     if (envProviderOptionsFromConfig === undefined) {
-      // TODO Zusammenstellen der Env-Provider-Einstellungen aus Dot-Keys
       const maybeEnvOptions = extractEnvProviderOptionsFromFlatRecord(
         jsonFileProvider.list(StarfleetDirectiveKey.envProviderOptions),
       );
-
-      console.debug('env configuration', { maybeEnvOptions });
 
       if (maybeEnvOptions && typeof maybeEnvOptions === 'object') {
         envProviderOptionsFromConfig = maybeEnvOptions;

--- a/src/setup/loadStarfleetDirectives.ts
+++ b/src/setup/loadStarfleetDirectives.ts
@@ -1,0 +1,98 @@
+/**
+ * @file loadStarfleetDirectives.ts
+ * @description Baut pro Szenario eine neue IStarfleetDirectives-Instanz auf Basis von:
+ *  - JSON-Providern (nur wenn Datei existiert)
+ *  - ENV-Provider (bekommt ungefiltert process.env + ggf. Optionen aus erster JSON-Datei)
+ *  - Memory-Provider (leer, szenario-lokal, höchste Priorität)
+ *
+ * Priorität (wegen preferFirst:true → erster gewinnt):
+ *  1) Memory
+ *  2) Env
+ *  3) JSON: ./test/acceptance/dqat.config.json
+ *  4) JSON: ./test/dqat.config.json
+ *  5) JSON: ./dqat.config.json
+ */
+
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { STARFLEET_DIRECTIVE_CONFIG_FILES } from '../config/starfleetDirectives.config.ts';
+import { StarfleetDirectiveKey } from '../config/starfleetDirectives.keys.ts';
+import { EnvProvider } from '../factory/provider/envProvider.ts';
+import { JsonFileProvider } from '../factory/provider/jsonFileProvider.ts';
+import { MemoryProvider } from '../factory/provider/memoryProvider.ts';
+import { createStarfleetDirectives } from '../factory/starfleetDirective.ts';
+import type { IEnvProviderOptions } from '../type/provider/providerOptions.ts';
+import type {
+  ILoadedStarfleetDirectives,
+  IStarfleetDirectiveProvider,
+} from '../type/starfleetDirective.ts';
+
+/**
+ * Erstellt pro Szenario eine frische Directives-Instanz.
+ *
+ * Ablauf:
+ * 1) JSON-Dateien in Prioritätsreihenfolge prüfen; pro vorhandener Datei einen JsonFileProvider erzeugen.
+ *    - Erste Datei mit Env-Optionen bestimmt die Env-Provider-Konfiguration (Key: "envProviderOptions").
+ * 2) Env-Provider mit vollständigem process.env und ggf. Options erzeugen.
+ * 3) Leeren Memory-Provider erzeugen.
+ * 4) Provider-Liste in Prioritätsreihenfolge zusammenstellen.
+ * 5) createStarfleetDirectives() mit preferFirst:true aufrufen.
+ */
+export function loadStarfleetDirectives(
+  additionalPaths: string[] = [],
+): ILoadedStarfleetDirectives {
+  const jsonProviders: IStarfleetDirectiveProvider[] = [];
+  let envProviderOptionsFromConfig: Partial<IEnvProviderOptions> | undefined;
+
+  const paths: string[] = [
+    ...STARFLEET_DIRECTIVE_CONFIG_FILES,
+    ...additionalPaths,
+  ];
+  for (const relativePath of paths) {
+    const absolutePath = resolve(process.cwd(), relativePath);
+    if (!existsSync(absolutePath)) {
+      continue;
+    }
+
+    const providerName = `json:${relativePath}`;
+    const jsonFileProvider = new JsonFileProvider(absolutePath, {
+      name: providerName,
+    });
+    jsonProviders.push(jsonFileProvider);
+
+    if (envProviderOptionsFromConfig === undefined) {
+      const maybeEnvOptions = jsonFileProvider.get(
+        StarfleetDirectiveKey.envProviderOptions,
+      ) as Partial<IEnvProviderOptions> | undefined;
+
+      if (maybeEnvOptions && typeof maybeEnvOptions === 'object') {
+        envProviderOptionsFromConfig = maybeEnvOptions;
+      }
+    }
+  }
+
+  const environmentMap: Record<string, string | undefined> = { ...process.env };
+  const envProvider = new EnvProvider(environmentMap, {
+    name: 'env',
+    ...(envProviderOptionsFromConfig ?? {}),
+  });
+
+  const memoryProvider = new MemoryProvider({}, { name: 'memory' });
+
+  const providersInPriorityOrder: IStarfleetDirectiveProvider[] = [
+    memoryProvider,
+    envProvider,
+    ...jsonProviders,
+  ];
+
+  // TODO Optionen aus starfleetDirectives laden
+  const starfleetDirectives = createStarfleetDirectives(
+    providersInPriorityOrder,
+    { preferFirst: true, freeze: true },
+  );
+
+  return {
+    starfleetDirectives,
+    memoryProvider,
+  };
+}

--- a/src/setup/loadStarfleetDirectives.ts
+++ b/src/setup/loadStarfleetDirectives.ts
@@ -23,8 +23,8 @@ import { MemoryProvider } from '../factory/provider/memoryProvider.ts';
 import { createStarfleetDirectives } from '../factory/starfleetDirective.ts';
 import type { IEnvProviderOptions } from '../type/provider/providerOptions.ts';
 import type {
-  ILoadedStarfleetDirectives,
-  IStarfleetDirectiveProvider,
+  LoadedStarfleetDirectives,
+  StarfleetDirectiveProvider,
 } from '../type/starfleetDirective.ts';
 
 /**
@@ -40,8 +40,8 @@ import type {
  */
 export function loadStarfleetDirectives(
   additionalPaths: string[] = [],
-): ILoadedStarfleetDirectives {
-  const jsonProviders: IStarfleetDirectiveProvider[] = [];
+): LoadedStarfleetDirectives {
+  const jsonProviders: StarfleetDirectiveProvider[] = [];
   let envProviderOptionsFromConfig: Partial<IEnvProviderOptions> | undefined;
 
   const paths: string[] = [
@@ -49,6 +49,7 @@ export function loadStarfleetDirectives(
     ...additionalPaths,
   ];
   for (const relativePath of paths) {
+    console.debug(`read the "${relativePath} config file`);
     const absolutePath = resolve(process.cwd(), relativePath);
     if (!existsSync(absolutePath)) {
       continue;
@@ -61,9 +62,12 @@ export function loadStarfleetDirectives(
     jsonProviders.push(jsonFileProvider);
 
     if (envProviderOptionsFromConfig === undefined) {
-      const maybeEnvOptions = jsonFileProvider.get(
-        StarfleetDirectiveKey.envProviderOptions,
-      ) as Partial<IEnvProviderOptions> | undefined;
+      // TODO Zusammenstellen der Env-Provider-Einstellungen aus Dot-Keys
+      const maybeEnvOptions = extractEnvProviderOptionsFromFlatRecord(
+        jsonFileProvider.list(StarfleetDirectiveKey.envProviderOptions),
+      );
+
+      console.debug('env configuration', { maybeEnvOptions });
 
       if (maybeEnvOptions && typeof maybeEnvOptions === 'object') {
         envProviderOptionsFromConfig = maybeEnvOptions;
@@ -79,7 +83,7 @@ export function loadStarfleetDirectives(
 
   const memoryProvider = new MemoryProvider({}, { name: 'memory' });
 
-  const providersInPriorityOrder: IStarfleetDirectiveProvider[] = [
+  const providersInPriorityOrder: StarfleetDirectiveProvider[] = [
     memoryProvider,
     envProvider,
     ...jsonProviders,
@@ -95,4 +99,125 @@ export function loadStarfleetDirectives(
     starfleetDirectives,
     memoryProvider,
   };
+}
+
+/**
+ * Extrahiert EnvProviderOptions aus flachen Starfleet-Directive-Keys
+ * und baut daraus ein verschachteltes Objekt.
+ *
+ * Unterstützt ausschließlich Keys der Form:
+ *   envProviderOptions.xxx
+ *
+ * Regeln:
+ * - Keys ohne Unterstruktur (z. B. "envProviderOptions") werden ignoriert
+ * - Unterstrukturen werden rekursiv aufgebaut (z. B. parse.numbers)
+ * - Wenn ein Key sowohl als Wert als auch als Objekt verwendet wird,
+ *   wird der direkte Wert ignoriert und die Unterstruktur verwendet
+ * - Mehrfache Definitionen desselben finalen Keys führen zu einem Fehler
+ * - Wenn keine passenden Keys existieren, wird `undefined` zurückgegeben
+ *
+ * @param flatRecord Flaches Record aus Provider.list()
+ * @returns Partial<IEnvProviderOptions> oder undefined
+ */
+function extractEnvProviderOptionsFromFlatRecord(
+  flatRecord: Record<string, unknown>,
+): Partial<IEnvProviderOptions> | undefined {
+  const prefix = 'envProviderOptions.';
+  const result: Record<string, unknown> = {};
+
+  let hasMatchingEntries = false;
+
+  for (const [fullKey, value] of Object.entries(flatRecord)) {
+    if (!fullKey.startsWith(prefix)) {
+      continue;
+    }
+
+    hasMatchingEntries = true;
+
+    const relativeKey = fullKey.slice(prefix.length);
+    assignNestedValue(result, relativeKey, value, fullKey);
+  }
+
+  return hasMatchingEntries
+    ? (result as Partial<IEnvProviderOptions>)
+    : undefined;
+}
+
+/**
+ * Schreibt einen Wert anhand eines Punkt-Pfades in ein verschachteltes Objekt.
+ *
+ * @param target Zielobjekt
+ * @param relativeKey Schlüssel ohne Prefix, z. B. "parse.numbers"
+ * @param value Zu setzender Wert
+ * @param originalKey Ursprünglicher vollständiger Schlüssel für Fehlermeldungen
+ */
+function assignNestedValue(
+  target: Record<string, unknown>,
+  relativeKey: string,
+  value: unknown,
+  originalKey: string,
+): void {
+  const pathSegments = relativeKey.split('.');
+  const lastSegmentIndex = pathSegments.length - 1;
+
+  let current = target;
+
+  for (const [index, segment] of pathSegments.entries()) {
+    const isLastSegment = index === lastSegmentIndex;
+
+    if (isLastSegment) {
+      assignFinalValue(current, segment, value, originalKey);
+      return;
+    }
+
+    current = ensureNestedObject(current, segment);
+  }
+}
+
+/**
+ * Stellt sicher, dass unter dem angegebenen Segment ein Objekt existiert.
+ * Falls dort bereits ein primitiver Wert steht, wird dieser verworfen.
+ *
+ * @param target Zielobjekt
+ * @param segment Aktuelles Pfadsegment
+ * @returns Das verschachtelte Objekt für das nächste Segment
+ */
+function ensureNestedObject(
+  target: Record<string, unknown>,
+  segment: string,
+): Record<string, unknown> {
+  const existingValue = target[segment];
+
+  if (
+    existingValue === undefined ||
+    typeof existingValue !== 'object' ||
+    existingValue === null
+  ) {
+    target[segment] = {};
+  }
+
+  return target[segment] as Record<string, unknown>;
+}
+
+/**
+ * Setzt einen finalen Wert. Doppelte finale Keys führen zu einem Fehler.
+ *
+ * @param target Zielobjekt
+ * @param segment Finales Pfadsegment
+ * @param value Zu setzender Wert
+ * @param originalKey Ursprünglicher vollständiger Schlüssel für Fehlermeldungen
+ */
+function assignFinalValue(
+  target: Record<string, unknown>,
+  segment: string,
+  value: unknown,
+  originalKey: string,
+): void {
+  if (Object.hasOwn(target, segment)) {
+    throw new Error(
+      `Duplicate EnvProviderOptions key detected: "${originalKey}"`,
+    );
+  }
+
+  target[segment] = value;
 }

--- a/src/setup/loadStarfleetDirectives.ts
+++ b/src/setup/loadStarfleetDirectives.ts
@@ -72,9 +72,12 @@ export function loadStarfleetDirectives(
   }
 
   const environmentMap: Record<string, string | undefined> = { ...process.env };
+  const envProviderOptions: IEnvProviderOptions = {
+    ...(envProviderOptionsFromConfig ?? {}),
+  };
   const envProvider = new EnvProvider(environmentMap, {
     name: 'env',
-    ...(envProviderOptionsFromConfig ?? {}),
+    ...envProviderOptions,
   });
 
   const memoryProvider = new MemoryProvider({}, { name: 'memory' });
@@ -94,6 +97,7 @@ export function loadStarfleetDirectives(
   return {
     starfleetDirectives,
     memoryProvider,
+    envProviderOptions,
   };
 }
 

--- a/src/setup/parameter.ts
+++ b/src/setup/parameter.ts
@@ -5,6 +5,7 @@ import { defineParameterType } from '@cucumber/cucumber';
  */
 export function registerParameter(): void {
   registerAstrometricsParameter();
+  registerHolodeckParameter();
 }
 
 /**
@@ -17,3 +18,8 @@ export function registerAstrometricsParameter(): void {
     transformer: (s) => s.toString(),
   });
 }
+
+/**
+ * Registriert alle Parameter für Holodeck
+ */
+export function registerHolodeckParameter(): void {}

--- a/src/step/directive.steps.ts
+++ b/src/step/directive.steps.ts
@@ -1,0 +1,7 @@
+import { Then } from '@cucumber/cucumber';
+import { assertDirectiveHasValueCallback } from '../callback/directive.ts';
+
+Then(
+  'sollte der Starfleet Directive Key {string} den Wert {string} haben',
+  assertDirectiveHasValueCallback,
+);

--- a/src/step/endpoint.steps.ts
+++ b/src/step/endpoint.steps.ts
@@ -1,0 +1,9 @@
+import { Then, When } from '@cucumber/cucumber';
+import {
+  expectLastResponseStatusCallback,
+  fetchRequestCallback,
+} from '../callback/endpoint.ts';
+
+When('ich den Endpunkt {string} über {word} abrufe', fetchRequestCallback);
+
+Then('erwarte ich den HTTP-Statuscode {int}', expectLastResponseStatusCallback);

--- a/src/step/holodeck.steps.ts
+++ b/src/step/holodeck.steps.ts
@@ -1,0 +1,15 @@
+import { Given, Then, When } from '@cucumber/cucumber';
+import {
+  expectNoActiveHolodeckCallback,
+  loadSceneCallback,
+  startHolodeckCallback,
+  stopHolodeckCallback,
+} from '../callback/holodeck.ts';
+
+Given('das Holodeck wurde im Modus {string} gestartet', startHolodeckCallback);
+
+When('die Holodeck-Szene {string} geladen wird', loadSceneCallback);
+
+When('das Holodeck gestoppt wird', stopHolodeckCallback);
+
+Then('ist kein Holodeck mehr aktiv', expectNoActiveHolodeckCallback);

--- a/src/step/index.ts
+++ b/src/step/index.ts
@@ -1,5 +1,6 @@
 // Alle Testschritte hier hinzufügen, die exportiert werden sollen
 import './clock.steps.ts';
+import './directive.steps.ts';
 import './endpoint.steps.ts';
 import './holodeck.steps.ts';
 import './mission-log.steps.ts';

--- a/src/step/index.ts
+++ b/src/step/index.ts
@@ -1,5 +1,7 @@
 // Alle Testschritte hier hinzufügen, die exportiert werden sollen
 import './clock.steps.ts';
+import './endpoint.steps.ts';
+import './holodeck.steps.ts';
 import './mission-log.steps.ts';
 import './resources.steps.ts';
 import './world.steps.ts';

--- a/src/type/ICucumberWorld.ts
+++ b/src/type/ICucumberWorld.ts
@@ -1,4 +1,11 @@
 import type { Astrometrics } from '../astrometrics/astrometrics.ts';
+import type {
+  IStarfleetDirectiveSchema,
+  TStarfleetDirectiveKey,
+} from '../config/starfleetDirectives.keys.ts';
+import type { Holodeck } from '../holodeck/holodeck.ts';
+import type { HttpResponseSnapshot } from './httpResponse.ts';
+import type { IStarfleetDirectives } from './starfleetDirective.ts';
 
 /**
  * Beschreibt die gemeinsame World-Schnittstelle für Szenarien.
@@ -7,6 +14,10 @@ import type { Astrometrics } from '../astrometrics/astrometrics.ts';
  * Ziel:
  * - Klare, schlanke Zugriffspunkte für Steps
  * - Astrometrics wird später hier eingebunden (Komposition)
+ * - eine fertig aufgebaute StarfleetDirectives-Instanz für Lookups bereit,
+ * - Hilfs-Methoden zum typsicheren Lesen/Prüfen/Listen von Directives,
+ * - sowie eine Möglichkeit, szenario-lokale Overrides (höchste Priorität)
+ *   über den Memory-Provider zu setzen.
  */
 export interface ICucumberWorld {
   /**
@@ -20,6 +31,20 @@ export interface ICucumberWorld {
   astrometrics?: Astrometrics;
 
   /**
+   * Laufende Holodeck-Instanz, falls gestartet.
+   * Wird von `startHolodeckCallback` gesetzt und von `stopHolodeckCallback` wieder entfernt.
+   */
+  holodeck?: Holodeck;
+
+  /**
+   * Das zuletzt erfasste HTTP-Antwort-Snapshot-Objekt.
+   * Wird typischerweise von fetchRequestCallback gesetzt
+   * und dann von Assertions (z. B. expectLastResponseStatusCallback)
+   * ausgewertet.
+   */
+  lastResponse?: HttpResponseSnapshot;
+
+  /**
    * Kurzform für Zeit (wird später an Astrometrics delegiert).
    * In der Setup-Phase bleibt das ein No-Op-Stub in Hooks.
    */
@@ -30,4 +55,53 @@ export interface ICucumberWorld {
    */
   get: (key: string) => unknown;
   set: (key: string, value: unknown) => void;
+
+  /**
+   * Liefert die schreibgeschützte StarfleetDirectives-Instanz für das Szenario.
+   * @returns IStarfleetDirectives
+   */
+  getStarfleetDirectives(): IStarfleetDirectives;
+
+  /**
+   * Typsicherer Zugriff auf Directives über vordefinierte Schlüssel.
+   * @param key Schlüsselliteral aus den bekannten Starfleet-Directive-Keys
+   * @returns Wert in passendem Typ oder `undefined`, falls unbekannt
+   */
+  getDirective<K extends TStarfleetDirectiveKey>(
+    key: K,
+  ): IStarfleetDirectiveSchema[K] | undefined;
+
+  /**
+   * Prüft, ob ein Directive-Key verfügbar ist (einschließlich Memory-Overrides).
+   * @param key Schlüsselliteral
+   * @returns true, wenn Wert existiert
+   */
+  hasDirective(key: TStarfleetDirectiveKey): boolean;
+
+  /**
+   * Listet alle bekannten Directives als flache Map. Optional per Präfix filtern.
+   * Rückgabe ist immutable (Deep-Freeze in der Factory).
+   * @param prefix Optionaler Präfix (z. B. "frontend.")
+   */
+  listDirectives(prefix?: string): Readonly<Record<string, unknown>>;
+
+  /**
+   * Setzt oder überschreibt einen Wert szenario-lokal im Memory-Provider
+   * (höchste Priorität in der Provider-Kette).
+   *
+   * Beispiel:
+   * ```ts
+   * world.setDirectiveOverride(
+   *   StarfleetDirectiveKey.frontendBaseUrl,
+   *   `http://localhost:${port}`,
+   * );
+   * ```
+   *
+   * @param key Schlüsselliteral aus StarfleetDirectiveKey
+   * @param value Wert im passenden Typ laut IStarfleetDirectiveSchema
+   */
+  setDirectiveOverride<K extends TStarfleetDirectiveKey>(
+    key: K,
+    value: IStarfleetDirectiveSchema[K],
+  ): void;
 }

--- a/src/type/ICucumberWorld.ts
+++ b/src/type/ICucumberWorld.ts
@@ -5,7 +5,7 @@ import type {
 } from '../config/starfleetDirectives.keys.ts';
 import type { Holodeck } from '../holodeck/holodeck.ts';
 import type { HttpResponseSnapshot } from './httpResponse.ts';
-import type { IStarfleetDirectives } from './starfleetDirective.ts';
+import type { StarfleetDirectives } from './starfleetDirective.ts';
 
 /**
  * Beschreibt die gemeinsame World-Schnittstelle für Szenarien.
@@ -60,7 +60,7 @@ export interface ICucumberWorld {
    * Liefert die schreibgeschützte StarfleetDirectives-Instanz für das Szenario.
    * @returns IStarfleetDirectives
    */
-  getStarfleetDirectives(): IStarfleetDirectives;
+  getStarfleetDirectives(): StarfleetDirectives;
 
   /**
    * Typsicherer Zugriff auf Directives über vordefinierte Schlüssel.

--- a/src/type/external/mockserver-node.d.ts
+++ b/src/type/external/mockserver-node.d.ts
@@ -102,7 +102,7 @@ declare module 'mockserver-node' {
      * Beispiel laut Doku:
      * "-Dmockserver.enableCORSForAllResponses=true"
      */
-    jvmOptions?: string;
+    jvmOptions?: string[];
 
     /**
      * Anzahl der Startup-Retry-Schleifen, um zu prüfen,

--- a/src/type/httpResponse.ts
+++ b/src/type/httpResponse.ts
@@ -1,0 +1,28 @@
+/**
+ * Repräsentiert den gespeicherten Stand einer HTTP-Antwort,
+ * damit spätere Prüf-Schritte (Assertions) darauf zugreifen können.
+ *
+ * Dieses Objekt wird z. B. von fetchRequestCallback gesetzt und
+ * von expectLastResponseStatusCallback ausgewertet.
+ *
+ * bodyText ist bewusst ein String, um Binär-/JSON-/Plaintext-Antworten
+ * zunächst unverändert zu puffern. Eine Interpretation (z. B. JSON.parse)
+ * findet erst in spezialisierten Auswertefunktionen statt.
+ */
+export interface HttpResponseSnapshot {
+  /**
+   * HTTP-Statuscode der Antwort (z. B. 200, 404, 500).
+   */
+  status: number;
+
+  /**
+   * Response-Header in normalisierter Form.
+   * Schlüssel werden in Kleinbuchstaben erwartet.
+   */
+  headers: Record<string, string>;
+
+  /**
+   * Antwort-Body als Rohtext.
+   */
+  bodyText: string;
+}

--- a/src/type/provider/providerOptions.ts
+++ b/src/type/provider/providerOptions.ts
@@ -5,7 +5,7 @@
  * - `separator` ist rein konventionell (Standard: ".") und wird nicht über den Typ erzwungen.
  * - `name` dient der Protokollierung / Diagnose und hat keine funktionale Bedeutung.
  */
-export interface BaseProviderOptions {
+export interface IBaseProviderOptions {
   /**
    * Logischer Name des Providers (für Logs / Diagnose).
    * Beispiel: "env", "jsonFile", "memory"
@@ -25,7 +25,7 @@ export interface BaseProviderOptions {
  * - false => keine Konvertierung, alles bleibt String
  * - Objekt => gezielte Aktivierung einzelner Konvertierungen
  */
-export type EnvParseOptions =
+export type IEnvParseOptions =
   | boolean
   | {
       /** Zahlen erkennen (z. B. "42" → 42) */
@@ -44,7 +44,7 @@ export type EnvParseOptions =
  *   Falls noch `includeUndefined` im Code existiert, sollte dies in der Factory
  *   auf `dropUndefined` (invertiert) gemappt werden.
  */
-export interface EnvProviderOptions extends BaseProviderOptions {
+export interface IEnvProviderOptions extends IBaseProviderOptions {
   /**
    * Optionales Präfix, das vor dem Lookup aus ENV-Variablen entfernt wird.
    * Beispiel: "DQ_" → "DQ_APP_PORT" wird zu "APP_PORT".
@@ -76,7 +76,7 @@ export interface EnvProviderOptions extends BaseProviderOptions {
    * - false => keine Konvertierung
    * - Objekt => gezielte Aktivierung einzelner Konvertierungen
    */
-  parse?: EnvParseOptions;
+  parse?: IEnvParseOptions;
 
   /**
    * Einheitliches Undefined-Handling:
@@ -93,14 +93,14 @@ export interface EnvProviderOptions extends BaseProviderOptions {
  * Aktuell gibt es keine zusätzlichen Felder gegenüber dem Basistyp.
  * Diese Schnittstelle existiert bewusst, um zukünftige Felder klar trennen zu können.
  */
-export interface JsonFileProviderOptions extends BaseProviderOptions {
+export interface IJsonFileProviderOptions extends IBaseProviderOptions {
   // (derzeit keine zusätzlichen Felder)
 }
 
 /**
  * Optionen speziell für den In-Memory-Provider.
  */
-export interface MemoryProviderOptions extends BaseProviderOptions {
+export interface IMemoryProviderOptions extends IBaseProviderOptions {
   /**
    * Steuert, ob Eingabestrukturen vor der Schlüsselauflösung flachgeklopft werden.
    * - true  => verschachtelte Objekte werden zu Dot-Keys
@@ -128,9 +128,9 @@ export interface MemoryProviderOptions extends BaseProviderOptions {
  * ohne providerspezifische Felder direkt zu benutzen.
  */
 export type AnyProviderOptions =
-  | EnvProviderOptions
-  | JsonFileProviderOptions
-  | MemoryProviderOptions;
+  | IEnvProviderOptions
+  | IJsonFileProviderOptions
+  | IMemoryProviderOptions;
 
 /**
  * Utility: Markiert nur ausgewählte Keys als required (mit NonNullable),
@@ -146,7 +146,7 @@ type WithRequired<T, K extends keyof T> = Omit<T, K> & {
  * - Alle übrigen bleiben optional.
  */
 export type NormalizedEnvOptions = WithRequired<
-  EnvProviderOptions,
+  IEnvProviderOptions,
   | 'separator'
   | 'doubleUnderscoreIsSeparator'
   | 'toLowerCase'
@@ -160,7 +160,7 @@ export type NormalizedEnvOptions = WithRequired<
  * - Alle übrigen bleiben optional.
  */
 export type NormalizedJsonFileOptions = WithRequired<
-  JsonFileProviderOptions,
+  IJsonFileProviderOptions,
   'separator'
 >;
 
@@ -170,6 +170,6 @@ export type NormalizedJsonFileOptions = WithRequired<
  * - Alle übrigen bleiben optional.
  */
 export type NormalizedMemoryOptions = WithRequired<
-  MemoryProviderOptions,
+  IMemoryProviderOptions,
   'separator' | 'flatten' | 'includeArrayIndices' | 'dropUndefined'
 >;

--- a/src/type/starfleetDirective.ts
+++ b/src/type/starfleetDirective.ts
@@ -3,7 +3,7 @@
  * z.B. In-Memory, Umgebungsvariablen oder JSON-Dateien. Provider dürfen Plattformdetails
  * enthalten, die Kern-Typen bleiben davon unabhängig.
  */
-export interface StarfleetDirectiveProvider {
+export interface IStarfleetDirectiveProvider {
   /**
    * Logischer Name des Providers (z.B. „memory“, „env“, „json“). Hilft beim Debugging
    * und in Log-Ausgaben. Namen sollten innerhalb einer Instanz eindeutig sein.
@@ -28,7 +28,7 @@ export interface StarfleetDirectiveProvider {
  * Öffentliche API für Tests/Framework-Komponenten, um deterministisch auf
  * Test-Konfigurationen („Directives“) zuzugreifen – unabhängig von der Quelle.
  */
-export interface StarfleetDirectives {
+export interface IStarfleetDirectives {
   /**
    * Exakten Key auflösen; unbekannt → `undefined` (kein Throw).
    * Beispiel: `resolveDirective('frontend.baseUrl')`.

--- a/src/type/starfleetDirective.ts
+++ b/src/type/starfleetDirective.ts
@@ -1,3 +1,5 @@
+import type { IEnvProviderOptions } from './provider/providerOptions.ts';
+
 /**
  * Ein Provider liefert Starfleet-Directives (Test-Konfigurationen) aus einer konkreten Quelle,
  * z.B. In-Memory, Umgebungsvariablen oder JSON-Dateien. Provider dürfen Plattformdetails
@@ -105,4 +107,18 @@ export interface LoadedStarfleetDirectives {
    * Szenarios verworfen.
    */
   readonly memoryProvider: StarfleetDirectiveProvider;
+
+  /**
+   * Effektiv verwendete Optionen für den Env-Provider.
+   *
+   * Diese Werte entsprechen den final aufgelösten Einstellungen, mit denen
+   * ENV-Variablen in Directive-Keys überführt wurden. Enthalten sind also
+   * nicht nur explizit gesetzte Konfigurationswerte, sondern auch übernommene
+   * Defaults, sofern die Ladefunktion diese bereits normalisiert.
+   *
+   * Das Feld ist primär für Tests, Debugging und transparente Nachvollziehbarkeit
+   * gedacht, damit geprüft werden kann, ob die erwartete ENV-Konfiguration
+   * tatsächlich aktiv ist.
+   */
+  readonly envProviderOptions: IEnvProviderOptions;
 }

--- a/src/type/starfleetDirective.ts
+++ b/src/type/starfleetDirective.ts
@@ -3,7 +3,7 @@
  * z.B. In-Memory, Umgebungsvariablen oder JSON-Dateien. Provider dürfen Plattformdetails
  * enthalten, die Kern-Typen bleiben davon unabhängig.
  */
-export interface IStarfleetDirectiveProvider {
+export interface StarfleetDirectiveProvider {
   /**
    * Logischer Name des Providers (z.B. „memory“, „env“, „json“). Hilft beim Debugging
    * und in Log-Ausgaben. Namen sollten innerhalb einer Instanz eindeutig sein.
@@ -28,7 +28,7 @@ export interface IStarfleetDirectiveProvider {
  * Öffentliche API für Tests/Framework-Komponenten, um deterministisch auf
  * Test-Konfigurationen („Directives“) zuzugreifen – unabhängig von der Quelle.
  */
-export interface IStarfleetDirectives {
+export interface StarfleetDirectives {
   /**
    * Exakten Key auflösen; unbekannt → `undefined` (kein Throw).
    * Beispiel: `resolveDirective('frontend.baseUrl')`.
@@ -77,7 +77,7 @@ export type StarfleetDirectivesOptions = {
  * Directives-Instanz und dem mutierbaren Memory-Provider, der
  * Szenario-übergreifend **nicht** geteilt wird.
  */
-export interface ILoadedStarfleetDirectives {
+export interface LoadedStarfleetDirectives {
   /**
    * Vollständig aufgebaute StarfleetDirectives-Instanz.
    *
@@ -88,7 +88,7 @@ export interface ILoadedStarfleetDirectives {
    * Diese Instanz ist während der Laufzeit **immutable** und wird für alle
    * Lookup-Operationen innerhalb des Szenarios verwendet.
    */
-  readonly starfleetDirectives: IStarfleetDirectives;
+  readonly starfleetDirectives: StarfleetDirectives;
 
   /**
    * Der szenario-lokale Memory-Provider, der in der Provider-Kette
@@ -104,5 +104,5 @@ export interface ILoadedStarfleetDirectives {
    * Der Memory-Provider ist **mutierbar** und wird nach Abschluss des
    * Szenarios verworfen.
    */
-  readonly memoryProvider: IStarfleetDirectiveProvider;
+  readonly memoryProvider: StarfleetDirectiveProvider;
 }

--- a/src/type/starfleetDirective.ts
+++ b/src/type/starfleetDirective.ts
@@ -45,6 +45,9 @@ export interface IStarfleetDirectives {
    * **immutable** (schreibgeschützt), um unbeabsichtigte Mutationen in Tests zu verhindern.
    */
   listDirectives(prefix?: string): Readonly<Record<string, unknown>>;
+
+  // TODO Docstring hinzufügen
+  hasProvider(providerName: string): boolean;
 }
 
 /**
@@ -64,3 +67,42 @@ export type StarfleetDirectivesOptions = {
    */
   freeze?: boolean;
 };
+
+/**
+ * Kapselt das Ergebnis des Ladevorgangs von StarfleetDirectives
+ * für ein einzelnes Szenario. Wird typischerweise beim Erzeugen
+ * einer neuen DqatWorld-Instanz verwendet.
+ *
+ * Diese Struktur trennt klar zwischen der schreibgeschützten
+ * Directives-Instanz und dem mutierbaren Memory-Provider, der
+ * Szenario-übergreifend **nicht** geteilt wird.
+ */
+export interface ILoadedStarfleetDirectives {
+  /**
+   * Vollständig aufgebaute StarfleetDirectives-Instanz.
+   *
+   * Sie kombiniert die Werte aller aktiven Provider (JSON, ENV, Memory)
+   * gemäß der Prioritätsregel (preferFirst = true) und stellt Methoden
+   * wie `resolveDirective()`, `hasDirective()` und `listDirectives()` bereit.
+   *
+   * Diese Instanz ist während der Laufzeit **immutable** und wird für alle
+   * Lookup-Operationen innerhalb des Szenarios verwendet.
+   */
+  readonly starfleetDirectives: IStarfleetDirectives;
+
+  /**
+   * Der szenario-lokale Memory-Provider, der in der Provider-Kette
+   * die höchste Priorität besitzt.
+   *
+   * Er dient dazu, Werte während eines Szenarios dynamisch zu setzen
+   * oder zu überschreiben – z. B. wenn ein Step im Testlauf Laufzeitdaten
+   * wie Ports, Tokens oder generierte IDs einträgt.
+   *
+   * Über diesen Provider werden von der DqatWorld-Instanz die Methoden
+   * `setDirectiveOverride()` und verwandte Helfer realisiert.
+   *
+   * Der Memory-Provider ist **mutierbar** und wird nach Abschluss des
+   * Szenarios verworfen.
+   */
+  readonly memoryProvider: IStarfleetDirectiveProvider;
+}

--- a/src/util/holodeck/shutdown.ts
+++ b/src/util/holodeck/shutdown.ts
@@ -1,0 +1,48 @@
+import type { DqatWorld } from '#setup';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Beendet das Holodeck kontrolliert und sichert zuvor die aufgezeichneten Logs.
+ *
+ * Die Methode übernimmt einen vollständigen Lifecycle-Abschluss des Holodecks:
+ * - Prüft, ob eine Holodeck-Instanz vorhanden ist (no-op, wenn nicht)
+ * - Liest alle aktuell vorhandenen Log-Nachrichten aus
+ * - Persistiert die Logs (z. B. als Report-Datei pro Szenario)
+ * - Beendet anschließend das Holodeck
+ * - Entfernt die Referenz aus der World (`world.holodeck = undefined`)
+ *
+ * Die Reihenfolge ist bewusst gewählt: Logs müssen vor dem Stop ausgelesen werden,
+ * da sie danach nicht mehr verfügbar sind.
+ *
+ * Die Methode ist idempotent ausgelegt und kann mehrfach aufgerufen werden,
+ * ohne unerwünschte Seiteneffekte zu verursachen.
+ *
+ * Typischer Einsatz:
+ * - Im Gherkin-Step „Wenn das Holodeck gestoppt wird“
+ * - Im After-Hook zur Sicherstellung eines sauberen Testabschlusses
+ */
+export async function shutdownHolodeckWithLogs(
+  world: DqatWorld,
+): Promise<void> {
+  if (!world.holodeck) {
+    return;
+  }
+
+  const scenarioId = world.get('scenario.id');
+  const reportDirectoryPath = join('test', 'reports', 'mockserver');
+  const reportFilePath = join(reportDirectoryPath, `${scenarioId}.log`);
+  mkdirSync(reportDirectoryPath, { recursive: true });
+
+  const mockserverMessage = await world.holodeck.retrieveLogMessages();
+  const lines: string[] = [
+    `Cucumber id: ${world.get('scenario.cucumberScenarioId')}`,
+    `Scenario name: ${world.get('scenario.name')}`,
+    `Scenario language: ${world.get('scenario.language')}`,
+    ...mockserverMessage,
+  ];
+  writeFileSync(reportFilePath, lines.join('\n'), 'utf8');
+
+  await world.holodeck.stop();
+  world.holodeck = undefined;
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,1 @@
+export { isStarfleetDirectiveKey } from './provider/keyResolution.ts';

--- a/src/util/provider/keyResolution.ts
+++ b/src/util/provider/keyResolution.ts
@@ -1,3 +1,6 @@
+import type { TStarfleetDirectiveKey } from '../../config/starfleetDirectives.keys.ts';
+import { StarfleetDirectiveKey } from '../../config/starfleetDirectives.keys.ts';
+
 /**
  * Entfernt ein optionales Präfix am Anfang eines Schlüssels.
  * Beispiel:
@@ -83,4 +86,32 @@ export function buildKey(
   separator: string,
 ): string {
   return parent ? `${parent}${separator}${current}` : current;
+}
+
+/**
+ * Prüft zur Laufzeit, ob der übergebene Schlüssel ein gültiger
+ * Starfleet-Directive-Key ist. Die Validierung erfolgt anhand der
+ * tatsächlichen Werte des Objekts `StarfleetDirectiveKey`.
+ *
+ * Diese Funktion dient als Runtime-Type-Guard, um unsichere Eingaben
+ * (z. B. aus Feature-Dateien, ENV-Werten oder JSON-Konfigurationen)
+ * abzusichern und anschließend das präzise Union-Type
+ * `TStarfleetDirectiveKey` nutzen zu können.
+ *
+ * @example
+ * const key = 'envProviderOptions';
+ * if (isStarfleetDirectiveKey(key)) {
+ *   // innerh. dieses Blocks ist key vom Typ TStarfleetDirectiveKey
+ *   const value = directives.resolveDirective(key);
+ * }
+ *
+ * @param candidateKey - Schlüssel, der geprüft werden soll.
+ * @returns `true`, wenn der Schlüssel im Union-Type enthalten ist.
+ */
+export function isStarfleetDirectiveKey(
+  candidateKey: string,
+): candidateKey is TStarfleetDirectiveKey {
+  return Object.values(StarfleetDirectiveKey).includes(
+    candidateKey as TStarfleetDirectiveKey,
+  );
 }

--- a/src/util/provider/optionNormalization.ts
+++ b/src/util/provider/optionNormalization.ts
@@ -1,14 +1,3 @@
-// src/util/provider/optionNormalization.ts
-
-import type {
-  EnvProviderOptions,
-  JsonFileProviderOptions,
-  MemoryProviderOptions,
-  NormalizedEnvOptions,
-  NormalizedJsonFileOptions,
-  NormalizedMemoryOptions,
-} from '../../type/provider/providerOptions.ts';
-import { normalizeParse } from './parsing.ts';
 import {
   DEFAULT_DOUBLE_UNDERSCORE_IS_SEPARATOR,
   DEFAULT_DROP_UNDEFINED,
@@ -17,7 +6,16 @@ import {
   DEFAULT_INCLUDE_ARRAY_INDICES,
   DEFAULT_SEPARATOR,
   DEFAULT_TO_LOWER_CASE,
-} from './providerDefaults.ts';
+} from '../../config/starfleetDirectives.config.ts';
+import type {
+  IEnvProviderOptions,
+  IJsonFileProviderOptions,
+  IMemoryProviderOptions,
+  NormalizedEnvOptions,
+  NormalizedJsonFileOptions,
+  NormalizedMemoryOptions,
+} from '../../type/provider/providerOptions.ts';
+import { normalizeParse } from './parsing.ts';
 
 /**
  * Normalisiert Optionen für den Env-Provider.
@@ -32,7 +30,7 @@ import {
  * Lässt `name` und `stripPrefix` optional.
  */
 export function normalizeEnvOptions(
-  input: EnvProviderOptions,
+  input: IEnvProviderOptions,
 ): NormalizedEnvOptions {
   const {
     name,
@@ -60,7 +58,7 @@ export function normalizeEnvOptions(
  * Setzt ausschließlich den Separator-Default; `name` bleibt optional.
  */
 export function normalizeJsonFileOptions(
-  input: JsonFileProviderOptions,
+  input: IJsonFileProviderOptions,
 ): NormalizedJsonFileOptions {
   const { name, separator = DEFAULT_SEPARATOR } = input ?? {};
   return { name, separator };
@@ -73,7 +71,7 @@ export function normalizeJsonFileOptions(
  * `name` bleibt optional.
  */
 export function normalizeMemoryOptions(
-  input: MemoryProviderOptions,
+  input: IMemoryProviderOptions,
 ): NormalizedMemoryOptions {
   const {
     name,

--- a/src/util/provider/parsing.ts
+++ b/src/util/provider/parsing.ts
@@ -1,11 +1,11 @@
 // src/util/provider/parsing.ts
 
+import { DEFAULT_ENV_PARSE } from '../../config/starfleetDirectives.config.ts';
 import {
   tryParseBoolean,
   tryParseJson,
   tryParseNumber,
 } from './parsing.helper.ts';
-import { DEFAULT_ENV_PARSE } from './providerDefaults.ts';
 
 /**
  * Flags zur Steuerung der String-Konvertierung.

--- a/test/acceptance/cucumber.config.cjs
+++ b/test/acceptance/cucumber.config.cjs
@@ -1,24 +1,31 @@
+const defaultConfig = {
+  paths: ['test/acceptance/feature/**/*.feature'],
+  requireModule: ['tsx/cjs', 'tsconfig-paths/register'],
+  require: [
+    'test/acceptance/setup.ts',
+    'src/step/**/*.ts',
+    'test/acceptance/step/**/*.ts',
+  ],
+  formatOptions: {
+    snippetInterface: 'async-await',
+  },
+  language: 'de',
+  publishQuiet: true,
+  format: [
+    'progress-bar',
+    'html:test/reports/cucumber/index.html',
+    'summary',
+    'snippets:test/reports/cucumber/snippets.txt',
+  ],
+};
+
+const ciConfig = {
+  ...defaultConfig,
+  tags: 'not @SkipOnPipeline',
+};
+
 /** @type {import('@cucumber/cucumber').IConfiguration} */
 module.exports = {
-  default: {
-    paths: ['test/acceptance/feature/**/*.feature'],
-    requireModule: ['tsx/cjs', 'tsconfig-paths/register'],
-    require: [
-      'test/acceptance/setup.ts',
-      'src/step/**/*.ts',
-      'test/acceptance/step/**/*.ts',
-    ],
-    formatOptions: {
-      snippetInterface: 'async-await',
-    },
-    language: 'de',
-    publishQuiet: true,
-    format: [
-      'progress-bar',
-      'html:test/reports/cucumber/index.html',
-      'summary',
-      'snippets:test/reports/cucumber/snippets.txt',
-    ],
-    // dryRun: true,
-  },
+  default: defaultConfig,
+  ci: ciConfig,
 };

--- a/test/acceptance/cucumber.config.cjs
+++ b/test/acceptance/cucumber.config.cjs
@@ -2,9 +2,8 @@
 module.exports = {
   default: {
     paths: ['test/acceptance/feature/**/*.feature'],
-    import: [
-      'tsx/register',
-      'tsconfig-paths/register',
+    requireModule: ['tsx/cjs', 'tsconfig-paths/register'],
+    require: [
       'test/acceptance/setup.ts',
       'src/step/**/*.ts',
       'test/acceptance/step/**/*.ts',

--- a/test/acceptance/dqat.config.json
+++ b/test/acceptance/dqat.config.json
@@ -1,0 +1,7 @@
+{
+  "envProviderOptions": {
+    "stripPrefix": "DQ_",
+    "toLowerCase": true,
+    "parse": true
+  }
+}

--- a/test/acceptance/feature/astrometrics/clock_mode.feature
+++ b/test/acceptance/feature/astrometrics/clock_mode.feature
@@ -1,30 +1,30 @@
 # language: de
 @astrometrics @clock
 Funktionalität: Uhr-Modi werden korrekt angewandt
-Damit zeitabhängige Schritte deterministisch ablaufen,
-möchte ich die World-Zeit über Modi steuern können.
+  Damit zeitabhängige Schritte deterministisch ablaufen,
+  möchte ich die World-Zeit über Modi steuern können.
 
-@clock:system
-Szenario: Systemuhr liefert aufsteigende Zeitstempel
-Angenommen die World ist initialisiert
-Wenn ich die aktuelle Zeit notiere
-Und ich notiere die aktuelle Zeit erneut
-Dann ist der zweite Zeitstempel größer oder gleich dem ersten
-Und der effektive Offset wird berücksichtigt
+  @clock:system
+  Szenario: Systemuhr liefert aufsteigende Zeitstempel
+    Angenommen die World ist initialisiert
+    Wenn ich die aktuelle Zeit notiere
+    Und ich notiere die aktuelle Zeit erneut
+    Dann ist der zweite Zeitstempel größer oder gleich dem ersten
+    Und der effektive Offset wird berücksichtigt
 
-@clock:frozen
-Szenario: Eingefrorene Uhr bleibt konstant bis zur Vorwärtsbewegung
-Angenommen die World ist initialisiert
-Und die Uhr ist auf den Zeitpunkt "2025-10-05T12:00:00Z" eingefroren
-Wenn ich die aktuelle Zeit notiere
-Und ich notiere die aktuelle Zeit erneut
-Dann sind beide Zeitstempel exakt gleich
-Wenn ich die Zeit um 5000 Millisekunden vorwärts bewege
-Und ich notiere die aktuelle Zeit erneut
-Dann liegt der neue Zeitstempel exakt 5000 Millisekunden über dem ersten
+  @clock:frozen
+  Szenario: Eingefrorene Uhr bleibt konstant bis zur Vorwärtsbewegung
+    Angenommen die World ist initialisiert
+    Und die Uhr ist auf den Zeitpunkt "2025-10-05T12:00:00Z" eingefroren
+    Wenn ich die aktuelle Zeit notiere
+    Und ich notiere die aktuelle Zeit erneut
+    Dann sind beide Zeitstempel exakt gleich
+    Wenn ich die Zeit um 5000 Millisekunden vorwärts bewege
+    Und ich notiere die aktuelle Zeit erneut
+    Dann liegt der neue Zeitstempel exakt 5000 Millisekunden über dem ersten
 
-@clock:monotonic
-Szenario: Monotone Uhr verhindert Rücksprünge
-Angenommen die World ist initialisiert
-Wenn ich mehrfach nacheinander die aktuelle Zeit notiere
-Dann ist die Sequenz der Zeitstempel monoton nicht fallend
+  @clock:monotonic
+  Szenario: Monotone Uhr verhindert Rücksprünge
+    Angenommen die World ist initialisiert
+    Wenn ich mehrfach nacheinander die aktuelle Zeit notiere
+    Dann ist die Sequenz der Zeitstempel monoton nicht fallend

--- a/test/acceptance/feature/astrometrics/clock_offset.feature
+++ b/test/acceptance/feature/astrometrics/clock_offset.feature
@@ -1,24 +1,24 @@
 # language: de
 @astrometrics @clock @offset
 Funktionalität: Uhr-Offsets wirken deterministisch
-Um Zeitzonen/Drift simulieren zu können,
-möchte ich Offsets auf alle Modi anwenden.
+  Um Zeitzonen/Drift simulieren zu können,
+  möchte ich Offsets auf alle Modi anwenden.
 
-@clock:system @clockOffset:+2000
-Szenario: Positiver Offset auf Systemuhr
-Angenommen die World ist initialisiert
-Wenn ich die Systemzeit und die World-Zeit parallel notiere
-Dann liegt die World-Zeit exakt 2000 Millisekunden über der Systemzeit
+  @clock:system @clockOffset:+2000
+  Szenario: Positiver Offset auf Systemuhr
+    Angenommen die World ist initialisiert
+    Wenn ich die Systemzeit und die World-Zeit parallel notiere
+    Dann liegt die World-Zeit exakt 2000 Millisekunden über der Systemzeit
 
-@clock:system @clockOffset:-3600000
-Szenario: Negativer Offset (eine Stunde zurück)
-Angenommen die World ist initialisiert
-Wenn ich die Systemzeit und die World-Zeit parallel notiere
-Dann liegt die World-Zeit exakt 3600000 Millisekunden unter der Systemzeit
+  @clock:system @clockOffset:-3600000
+  Szenario: Negativer Offset (eine Stunde zurück)
+    Angenommen die World ist initialisiert
+    Wenn ich die Systemzeit und die World-Zeit parallel notiere
+    Dann liegt die World-Zeit exakt 3600000 Millisekunden unter der Systemzeit
 
-@clock:frozen @clockOffset:+2000
-Szenario: Offset + eingefrorene Uhr + Vorwärtsbewegung
-Angenommen die World ist initialisiert
-Und die Uhr ist auf den Zeitpunkt "2025-10-05T12:00:00Z" eingefroren
-Wenn ich die Zeit um 3000 Millisekunden vorwärts bewege
-Dann liegt die World-Zeit exakt 5000 Millisekunden über dem Ankerzeitpunkt
+  @clock:frozen @clockOffset:+2000
+  Szenario: Offset + eingefrorene Uhr + Vorwärtsbewegung
+    Angenommen die World ist initialisiert
+    Und die Uhr ist auf den Zeitpunkt "2025-10-05T12:00:00Z" eingefroren
+    Wenn ich die Zeit um 3000 Millisekunden vorwärts bewege
+    Dann liegt die World-Zeit exakt 5000 Millisekunden über dem Ankerzeitpunkt

--- a/test/acceptance/feature/astrometrics/invalid_tags.feature
+++ b/test/acceptance/feature/astrometrics/invalid_tags.feature
@@ -4,7 +4,7 @@ Funktionalität: Ungültige Tags werden fehlertolerant behandelt
   Um Stabilität zu sichern,
   möchte ich ungültige Tag-Werte ignorieren und warnen.
 
-  @clock:warp9 @clockOffset:NaN
+  @clock:warp9 @clockOffset:NaN @SkipOnPipeline
   Szenario: Ungültige Clock- und Offset-Tags
     Angenommen die World ist initialisiert
     Wenn das Szenario startet

--- a/test/acceptance/feature/astrometrics/isolation_cleanup.feature
+++ b/test/acceptance/feature/astrometrics/isolation_cleanup.feature
@@ -4,7 +4,7 @@ Funktionalität: Isolation und Cleanup pro Szenario
   Um Nebeneffekte zu vermeiden,
   möchte ich Ressourcen szenario-lokal verwalten und deterministisch aufräumen.
 
-  @worldSeed:one
+  @worldSeed:one @SkipOnPipeline
   Szenario: Ressourcen werden in LIFO-Reihenfolge entsorgt
     Angenommen die World ist initialisiert
     Und ich registriere eine Ressource "A" mit Disposer
@@ -15,7 +15,7 @@ Funktionalität: Isolation und Cleanup pro Szenario
     Und Fehler in einzelnen Disposern werden protokolliert, blockieren aber das Aufräumen nicht
     Und nach dem Aufräumen sind keine aktiven Timer oder Sockets mehr vorhanden
 
-  @parallel @worldSeed:X
+  @parallel @worldSeed:X @SkipOnPipeline
   Szenario: Szenarien sind isoliert (keine Leaks)
     Angenommen die World ist initialisiert
     Und ich registriere eine Ressource "mockServer" mit Disposer

--- a/test/acceptance/feature/astrometrics/mission_log_correlation.feature
+++ b/test/acceptance/feature/astrometrics/mission_log_correlation.feature
@@ -4,7 +4,7 @@ Funktionalität: MissionLog enthält korrekte Korrelation
   Um Ereignisse nachvollziehen zu können,
   möchte ich strukturierte Logeinträge mit Korrelation schreiben.
 
-  @clock:frozen @worldSeed:42
+  @clock:frozen @worldSeed:42 @SkipOnPipeline
   Szenario: Logeintrag trägt World-Zeit und Korrelation
     Angenommen die World ist initialisiert
     Und runId, scenarioId und stepId sind gesetzt

--- a/test/acceptance/feature/astrometrics/seed_determinism.feature
+++ b/test/acceptance/feature/astrometrics/seed_determinism.feature
@@ -4,21 +4,21 @@ Funktionalität: Seed stellt Reproduzierbarkeit sicher
   Um deterministische Daten zu erzeugen,
   möchte ich Seeds pro Szenario festlegen.
 
-  @worldSeed:42
+  @worldSeed:42 @SkipOnPipeline
   Szenario: Gleicher Seed liefert gleiche Ergebnisse (Lauf A)
     Angenommen die World ist initialisiert
     Und ich erzeuge seed-abhängige Testdaten mit denselben Eingaben
     Wenn ich die erzeugten Werte notiere
     Dann entsprechen die Werte der bekannten Baseline für Seed "42"
 
-  @worldSeed:42
+  @worldSeed:42 @SkipOnPipeline
   Szenario: Gleicher Seed liefert gleiche Ergebnisse (Lauf B)
     Angenommen die World ist initialisiert
     Und ich erzeuge seed-abhängige Testdaten mit denselben Eingaben
     Wenn ich die erzeugten Werte notiere
     Dann entsprechen die Werte exakt den Werten aus Lauf A
 
-  @worldSeed:A
+  @worldSeed:A @SkipOnPipeline
   Szenario: Unterschiedliche Seeds unterscheiden sich erwartungsgemäß
     Angenommen die World ist initialisiert
     Und ich erzeuge seed-abhängige Testdaten mit denselben Eingaben

--- a/test/acceptance/feature/holodeck/start_and_stop.feature
+++ b/test/acceptance/feature/holodeck/start_and_stop.feature
@@ -1,0 +1,19 @@
+# language: de
+@Wip
+Funktionalität: Holodeck starten, Szene laden und Antwort prüfen
+    Um deterministische Tests zu ermöglichen,
+    möchte ich ein Holodeck starten, eine vorbereitete Szene aktivieren
+    und die Antworten dieser Szene über HTTP abrufen.
+
+    Hintergrund:
+        Angenommen das Holodeck wurde im Modus "embedded" gestartet
+
+    Szenario: Happy-Path: bekannte Szene "happy" laden und erfolgreichen Endpunkt abrufen
+        Wenn die Holodeck-Szene "happy" geladen wird
+        Und ich den Endpunkt "/api/status" über GET abrufe
+        Dann erwarte ich den HTTP-Statuscode 200
+        Und das Holodeck gestoppt wird
+
+    Szenario: Cleanup: Holodeck stoppen nach dem Testlauf
+        Wenn das Holodeck gestoppt wird
+        Dann ist kein Holodeck mehr aktiv

--- a/test/acceptance/feature/holodeck/start_and_stop.feature
+++ b/test/acceptance/feature/holodeck/start_and_stop.feature
@@ -1,19 +1,18 @@
 # language: de
-@Wip
 Funktionalität: Holodeck starten, Szene laden und Antwort prüfen
-    Um deterministische Tests zu ermöglichen,
-    möchte ich ein Holodeck starten, eine vorbereitete Szene aktivieren
-    und die Antworten dieser Szene über HTTP abrufen.
+  Um deterministische Tests zu ermöglichen,
+  möchte ich ein Holodeck starten, eine vorbereitete Szene aktivieren
+  und die Antworten dieser Szene über HTTP abrufen.
 
-    Hintergrund:
-        Angenommen das Holodeck wurde im Modus "embedded" gestartet
+  Hintergrund:
+    Angenommen das Holodeck wurde im Modus "embedded" gestartet
 
-    Szenario: Happy-Path: bekannte Szene "happy" laden und erfolgreichen Endpunkt abrufen
-        Wenn die Holodeck-Szene "happy" geladen wird
-        Und ich den Endpunkt "/api/status" über GET abrufe
-        Dann erwarte ich den HTTP-Statuscode 200
-        Und das Holodeck gestoppt wird
+  Szenario: Happy-Path: bekannte Szene "happy" laden und erfolgreichen Endpunkt abrufen
+    Wenn die Holodeck-Szene "happy" geladen wird
+    Und ich den Endpunkt "/api/status" über GET abrufe
+    Dann erwarte ich den HTTP-Statuscode 200
+    Und das Holodeck gestoppt wird
 
-    Szenario: Cleanup: Holodeck stoppen nach dem Testlauf
-        Wenn das Holodeck gestoppt wird
-        Dann ist kein Holodeck mehr aktiv
+  Szenario: Cleanup: Holodeck stoppen nach dem Testlauf
+    Wenn das Holodeck gestoppt wird
+    Dann ist kein Holodeck mehr aktiv

--- a/test/acceptance/feature/setup/load-starfleet-directives.feature
+++ b/test/acceptance/feature/setup/load-starfleet-directives.feature
@@ -29,16 +29,27 @@ Funktionalität: Laden der Starfleet Directives
     Und es existieren folgende Starfleet Directives
         | Key  | Wert  |
         | test | false |
-    Dann sollte der Memory-Provider höchste Priorität haben
-    Und der ENV-Provider sollte die JSON-Provider überschreiben
-    Und die Datei "./test/acceptance/test.config.json" sollte Vorrang vor "./test/test.config.json" haben
+    Dann sollte der Starfleet Directive Key "test" den Wert "false" haben
+    Dann sollte der Starfleet Directive Key "test2" den Wert "Dies ist ein Test" haben
+    Dann sollte der Starfleet Directive Key "path" den Wert "env" haben
 
   Szenario: Laden der ENV-Provider-Optionen aus erster Datei
-    Angenommen die Datei "./test/acceptance/dqat.config.json" enthält den Eintrag "envProviderOptions"
+    # Angenommen die Datei "./test/acceptance/providerOptions.config.json" enthält die Provider-Optionen
+    #     | Property                    | Wert  |
+    #     | stripPrefix                 | TEST_ |
+    #     | toLowerCase                 | true  |
+    #     | parse                       | true  |
+    #     | defaultSeparator            | ;     |
+    #     | doubleUnderscoreIsSeparator | false |
+    #     | dropUndefined               | false |
     Wenn die Starfleet Directives geladen werden
-    Dann sollten die ENV-Provider-Optionen aus dieser Datei übernommen werden
-    Und keine späteren Dateien dürfen diese überschreiben
+    Dann sollten die ENV-Provider-Optionen so eingestellt sein
+        | Property    | Wert |
+        | stripPrefix | DQ_  |
+        | toLowerCase | true |
+        | parse       | true |
 
+  @SkipOnPipeline
   Szenario: Keine JSON-Dateien vorhanden
     Angenommen keine der Standard-Konfigurationsdateien existiert
     Wenn die Starfleet Directives geladen werden

--- a/test/acceptance/feature/setup/load-starfleet-directives.feature
+++ b/test/acceptance/feature/setup/load-starfleet-directives.feature
@@ -1,0 +1,45 @@
+# language: de
+@setup
+Funktionalität: Laden der Starfleet Directives
+
+  Ziel:
+  Überprüfen, dass beim Start eines Szenarios die Konfigurationsdateien,
+  ENV-Variablen und der Memory-Provider korrekt geladen und
+  miteinander kombiniert werden.
+
+  Hintergrund:
+    Angenommen folgende JSON-Konfigurationsdateien existieren:
+        | Pfad                               | JSON                                    |
+        | ./test.config.json                 | {"test": true}                          |
+        | ./test/test.config.json            | {"test2": "Dies ist ein Test"}          |
+        | ./test/acceptance/test.config.json | {"test3": "Dies ist ein erneuter Test"} |
+    Und die ENV-Variable "DQ_TEST_MODE" ist gesetzt auf "true"
+
+  Szenario: Laden aller gültigen Provider
+    Wenn die Starfleet Directives für das Szenario geladen werden
+    Dann sollte der JSON-Provider für "test/acceptance/test.config.json" existieren
+    Und der JSON-Provider für "test/test.config.json" existieren
+    Und der JSON-Provider für "test.config.json" existieren
+    Und der ENV-Provider sollte geladen sein
+    Und der Memory-Provider sollte geladen sein
+
+  Szenario: Priorität der Provider
+    Angenommen es existieren folgende Starfleet Directives
+        | Key  | Wert  |
+        | test | false |
+    Wenn die Starfleet Directives geladen werden
+    Dann sollte der Memory-Provider höchste Priorität haben
+    Und der ENV-Provider sollte die JSON-Provider überschreiben
+    Und die Datei "./test/acceptance/dqat.config.json" sollte Vorrang vor "./test/dqat.config.json" haben
+
+  Szenario: Laden der ENV-Provider-Optionen aus erster Datei
+    Angenommen die Datei "./test/acceptance/dqat.config.json" enthält den Eintrag "envProviderOptions"
+    Wenn die Starfleet Directives geladen werden
+    Dann sollten die ENV-Provider-Optionen aus dieser Datei übernommen werden
+    Und keine späteren Dateien dürfen diese überschreiben
+
+  Szenario: Keine JSON-Dateien vorhanden
+    Angenommen keine der Standard-Konfigurationsdateien existiert
+    Wenn die Starfleet Directives geladen werden
+    Dann sollte nur der ENV-Provider und der Memory-Provider aktiv sein
+    Und es sollte kein Fehler geworfen werden

--- a/test/acceptance/feature/setup/load-starfleet-directives.feature
+++ b/test/acceptance/feature/setup/load-starfleet-directives.feature
@@ -1,5 +1,6 @@
 # language: de
 @setup
+@Wip
 Funktionalität: Laden der Starfleet Directives
 
   Ziel:

--- a/test/acceptance/feature/setup/load-starfleet-directives.feature
+++ b/test/acceptance/feature/setup/load-starfleet-directives.feature
@@ -10,14 +10,14 @@ Funktionalität: Laden der Starfleet Directives
 
   Hintergrund:
     Angenommen folgende JSON-Konfigurationsdateien existieren:
-        | Pfad                               | JSON                                    |
-        | ./test.config.json                 | {"test": true}                          |
-        | ./test/test.config.json            | {"test2": "Dies ist ein Test"}          |
-        | ./test/acceptance/test.config.json | {"test3": "Dies ist ein erneuter Test"} |
-    Und die ENV-Variable "DQ_TEST_MODE" ist gesetzt auf "true"
+        | Pfad                               | JSON                                                               |
+        | ./test.config.json                 | {"test": true, "path": "root"}                                     |
+        | ./test/test.config.json            | {"test2": "Dies ist ein Test", "path": "test"}                     |
+        | ./test/acceptance/test.config.json | {"test2": "Dies ist ein erneuter Test", "path": "test/acceptance"} |
+    Und die ENV-Variable "DQ_PATH" ist gesetzt auf "env"
 
   Szenario: Laden aller gültigen Provider
-    Wenn die Starfleet Directives für das Szenario geladen werden
+    Wenn die Starfleet Directives geladen werden
     Dann sollte der JSON-Provider für "test/acceptance/test.config.json" existieren
     Und der JSON-Provider für "test/test.config.json" existieren
     Und der JSON-Provider für "test.config.json" existieren
@@ -25,13 +25,13 @@ Funktionalität: Laden der Starfleet Directives
     Und der Memory-Provider sollte geladen sein
 
   Szenario: Priorität der Provider
-    Angenommen es existieren folgende Starfleet Directives
+    Wenn die Starfleet Directives geladen werden
+    Und es existieren folgende Starfleet Directives
         | Key  | Wert  |
         | test | false |
-    Wenn die Starfleet Directives geladen werden
     Dann sollte der Memory-Provider höchste Priorität haben
     Und der ENV-Provider sollte die JSON-Provider überschreiben
-    Und die Datei "./test/acceptance/dqat.config.json" sollte Vorrang vor "./test/dqat.config.json" haben
+    Und die Datei "./test/acceptance/test.config.json" sollte Vorrang vor "./test/test.config.json" haben
 
   Szenario: Laden der ENV-Provider-Optionen aus erster Datei
     Angenommen die Datei "./test/acceptance/dqat.config.json" enthält den Eintrag "envProviderOptions"
@@ -42,5 +42,6 @@ Funktionalität: Laden der Starfleet Directives
   Szenario: Keine JSON-Dateien vorhanden
     Angenommen keine der Standard-Konfigurationsdateien existiert
     Wenn die Starfleet Directives geladen werden
-    Dann sollte nur der ENV-Provider und der Memory-Provider aktiv sein
+    Dann der ENV-Provider sollte geladen sein
+    Und der Memory-Provider sollte geladen sein
     Und es sollte kein Fehler geworfen werden

--- a/test/acceptance/fixtures/holodeck/happy.scene.json
+++ b/test/acceptance/fixtures/holodeck/happy.scene.json
@@ -1,4 +1,5 @@
 {
+  "version": 1,
   "name": "happy",
   "routes": [
     {

--- a/test/acceptance/fixtures/holodeck/happy.scene.json
+++ b/test/acceptance/fixtures/holodeck/happy.scene.json
@@ -1,0 +1,24 @@
+{
+  "name": "happy",
+  "routes": [
+    {
+      "id": "get-status",
+      "request": {
+        "method": "GET",
+        "path": "/api/status"
+      },
+      "response": {
+        "statusCode": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "status": "ok"
+        }
+      },
+      "times": {
+        "unlimited": true
+      }
+    }
+  ]
+}

--- a/test/acceptance/step/astrometrics/setup.steps.ts
+++ b/test/acceptance/step/astrometrics/setup.steps.ts
@@ -44,23 +44,19 @@ Given(
     for (const row of rows) {
       const key = row.Key;
       if (!key || !isStarfleetDirectiveKey(key)) {
-        throw new Error(`The key “${key}” is not a valid key.`);
+        console.warn(`The key “${key}” is not a valid key.`);
       }
-      this.setDirectiveOverride<typeof key>(key, row.Wert);
+      this.setDirectiveOverride(key, row.Wert);
     }
   },
 );
 
 When(
-  'die Starfleet Directives für das Szenario geladen werden',
+  'die Starfleet Directives geladen werden',
   async function (this: DqatAcceptanceWorld) {
     this.loadStarfleetDirectives(this.testPaths);
   },
 );
-
-When('die Starfleet Directives geladen werden', async function () {
-  this.loadStarfleetDirectives(this.testPaths);
-});
 
 Then(
   'sollte der JSON-Provider für {string} existieren',
@@ -102,7 +98,51 @@ Then(
   },
 );
 
-Then('sollte der Memory-Provider höchste Priorität haben', async function () {
-  // Write code here that turns the phrase above into concrete actions
-  return 'pending';
-});
+Then(
+  'sollte der Memory-Provider höchste Priorität haben',
+  async function (this: DqatAcceptanceWorld) {
+    const directiveValue =
+      this.getStarfleetDirectives().resolveDirective('test');
+
+    assert.notStrictEqual(
+      directiveValue,
+      undefined,
+      `Für den Key "test" wurde kein Wert gefunden.`,
+    );
+
+    assert.strictEqual(
+      directiveValue,
+      'false',
+      'Der Memory-Provider hat nicht die höchste Priorität.',
+    );
+  },
+);
+
+Then(
+  'der ENV-Provider sollte die JSON-Provider überschreiben',
+  async function (this: DqatAcceptanceWorld) {
+    const value = this.getStarfleetDirectives().resolveDirective('path');
+
+    // Existenz prüfen
+    assert.notStrictEqual(
+      value,
+      undefined,
+      'Erwarteter Wert aus ENV ist undefined',
+    );
+
+    // Inhalt prüfen
+    assert.strictEqual(
+      value,
+      'env',
+      'ENV-Provider hat JSON-Wert nicht überschrieben',
+    );
+  },
+);
+
+Then(
+  'die Datei "./test/acceptance/test.config.json" sollte Vorrang vor "./test/test.config.json" haben',
+  async function (this: DqatAcceptanceWorld) {
+    // Write code here that turns the phrase above into concrete actions
+    return 'pending';
+  },
+);

--- a/test/acceptance/step/astrometrics/setup.steps.ts
+++ b/test/acceptance/step/astrometrics/setup.steps.ts
@@ -24,6 +24,30 @@ Given(
 );
 
 Given(
+  'die Datei {string} enthält die Provider-Optionen',
+  async function (
+    this: DqatAcceptanceWorld,
+    filePath: string,
+    dataTable: DataTable,
+  ) {
+    const providerOptions: Record<string, unknown> = {};
+    const rows = dataTable.hashes();
+
+    for (const row of rows) {
+      if (row.Property) {
+        providerOptions[row.Property] = row.Wert;
+      }
+    }
+
+    this.testPaths.push(
+      makeJsonFile(filePath, 'dqat-provider-options', {
+        envProviderOptions: providerOptions,
+      }),
+    );
+  },
+);
+
+Given(
   'die ENV-Variable {string} ist gesetzt auf {string}',
   async function (
     this: DqatAcceptanceWorld,
@@ -46,7 +70,9 @@ Given(
       if (!key || !isStarfleetDirectiveKey(key)) {
         console.warn(`The key “${key}” is not a valid key.`);
       }
-      this.setDirectiveOverride(key, row.Wert);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      this.setDirectiveOverride(key as any, row.Wert);
     }
   },
 );
@@ -99,50 +125,34 @@ Then(
 );
 
 Then(
-  'sollte der Memory-Provider höchste Priorität haben',
-  async function (this: DqatAcceptanceWorld) {
-    const directiveValue =
-      this.getStarfleetDirectives().resolveDirective('test');
+  'sollten die ENV-Provider-Optionen so eingestellt sein',
+  async function (this: DqatAcceptanceWorld, dataTable: DataTable) {
+    const rows = dataTable.hashes();
+    const envProviderOptions = this.getEnvProviderOptions();
 
-    assert.notStrictEqual(
-      directiveValue,
-      undefined,
-      `Für den Key "test" wurde kein Wert gefunden.`,
+    assert.ok(
+      envProviderOptions,
+      'Die envProviderOptions sind nicht gesetzt oder konnten nicht geladen werden.',
     );
 
-    assert.strictEqual(
-      directiveValue,
-      'false',
-      'Der Memory-Provider hat nicht die höchste Priorität.',
-    );
-  },
-);
+    for (const row of rows) {
+      const key = row.Property;
+      const hasProperty = Object.hasOwn(envProviderOptions, key);
 
-Then(
-  'der ENV-Provider sollte die JSON-Provider überschreiben',
-  async function (this: DqatAcceptanceWorld) {
-    const value = this.getStarfleetDirectives().resolveDirective('path');
+      assert.ok(
+        hasProperty,
+        `In envProviderOptions ist der Key "${key}" nicht gesetzt.`,
+      );
 
-    // Existenz prüfen
-    assert.notStrictEqual(
-      value,
-      undefined,
-      'Erwarteter Wert aus ENV ist undefined',
-    );
+      const actualValue =
+        envProviderOptions[key as keyof typeof envProviderOptions]?.toString();
+      const expectedValue = row.Wert;
 
-    // Inhalt prüfen
-    assert.strictEqual(
-      value,
-      'env',
-      'ENV-Provider hat JSON-Wert nicht überschrieben',
-    );
-  },
-);
-
-Then(
-  'die Datei "./test/acceptance/test.config.json" sollte Vorrang vor "./test/test.config.json" haben',
-  async function (this: DqatAcceptanceWorld) {
-    // Write code here that turns the phrase above into concrete actions
-    return 'pending';
+      assert.equal(
+        actualValue,
+        expectedValue,
+        `Der Wert der Option "${key}" ist falsch gesetzt`,
+      );
+    }
   },
 );

--- a/test/acceptance/step/astrometrics/setup.steps.ts
+++ b/test/acceptance/step/astrometrics/setup.steps.ts
@@ -1,0 +1,108 @@
+import type { DataTable } from '@cucumber/cucumber';
+import { Given, Then, When } from '@cucumber/cucumber';
+import assert from 'node:assert';
+import { isStarfleetDirectiveKey } from '../../../../src/util/provider/keyResolution.ts';
+import { makeJsonFile } from '../../../util/jsonFileProvider.helper.ts';
+import type { DqatAcceptanceWorld } from '../../type/acceptanceWorld.ts';
+
+Given(
+  'folgende JSON-Konfigurationsdateien existieren:',
+  async function (this: DqatAcceptanceWorld, dataTable: DataTable) {
+    const rows = dataTable.hashes();
+    for (const row of rows) {
+      if (row.Pfad) {
+        this.testPaths.push(
+          makeJsonFile(
+            row.Pfad,
+            'dqat-acceptance-setup',
+            row.JSON ? JSON.parse(row.JSON) : {},
+          ),
+        );
+      }
+    }
+  },
+);
+
+Given(
+  'die ENV-Variable {string} ist gesetzt auf {string}',
+  async function (
+    this: DqatAcceptanceWorld,
+    envVariable: string,
+    value: string,
+  ) {
+    if (!envVariable || !value) {
+      throw new Error('Env variable name and value must be set.');
+    }
+    process.env[envVariable] = value;
+  },
+);
+
+Given(
+  'es existieren folgende Starfleet Directives',
+  async function (this: DqatAcceptanceWorld, dataTable: DataTable) {
+    const rows = dataTable.hashes();
+    for (const row of rows) {
+      const key = row.Key;
+      if (!key || !isStarfleetDirectiveKey(key)) {
+        throw new Error(`The key “${key}” is not a valid key.`);
+      }
+      this.setDirectiveOverride<typeof key>(key, row.Wert);
+    }
+  },
+);
+
+When(
+  'die Starfleet Directives für das Szenario geladen werden',
+  async function (this: DqatAcceptanceWorld) {
+    this.loadStarfleetDirectives(this.testPaths);
+  },
+);
+
+When('die Starfleet Directives geladen werden', async function () {
+  this.loadStarfleetDirectives(this.testPaths);
+});
+
+Then(
+  'sollte der JSON-Provider für {string} existieren',
+  async function (this: DqatAcceptanceWorld, providerName: string) {
+    assert.ok(
+      this.getStarfleetDirectives().hasProvider(providerName),
+      `Der Provider "${providerName}" wurde nicht geladen`,
+    );
+  },
+);
+
+Then(
+  'der JSON-Provider für {string} existieren',
+  async function (this: DqatAcceptanceWorld, providerName: string) {
+    assert.ok(
+      this.getStarfleetDirectives().hasProvider(providerName),
+      `Der Provider "${providerName}" wurde nicht geladen`,
+    );
+  },
+);
+
+Then(
+  'der ENV-Provider sollte geladen sein',
+  async function (this: DqatAcceptanceWorld) {
+    assert.ok(
+      this.getStarfleetDirectives().hasProvider('env'),
+      `Der Env-Provider wurde nicht geladen`,
+    );
+  },
+);
+
+Then(
+  'der Memory-Provider sollte geladen sein',
+  async function (this: DqatAcceptanceWorld) {
+    assert.ok(
+      this.getStarfleetDirectives().hasProvider('memory'),
+      `Der Memory-Provider wurde nicht geladen`,
+    );
+  },
+);
+
+Then('sollte der Memory-Provider höchste Priorität haben', async function () {
+  // Write code here that turns the phrase above into concrete actions
+  return 'pending';
+});

--- a/test/acceptance/type/acceptanceWorld.ts
+++ b/test/acceptance/type/acceptanceWorld.ts
@@ -5,4 +5,9 @@ import { DqatWorld } from '@RMajewski/dqat-core/setup';
  * Ergänzt die Basis-World (`DqatWorld`) um test-spezifische Felder,
  * die in Feature-Schritten wie Clock, Zeitvergleiche, API-Checks usw. verwendet werden.
  */
-export class DqatAcceptanceWorld extends DqatWorld {}
+export class DqatAcceptanceWorld extends DqatWorld {
+  /**
+   * Zusätzliche Pfade zum testen, ob die Starfleet-Directives richtig geladen werden.
+   */
+  public testPaths: string[] = [];
+}

--- a/test/unit/factory/provider/jsonFileProvider.spec.ts
+++ b/test/unit/factory/provider/jsonFileProvider.spec.ts
@@ -3,28 +3,22 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { JsonFileProvider } from '../../../../src/factory/provider/jsonFileProvider.ts';
+import { makeJsonFile } from '../../../util/jsonFileProvider.helper.ts';
 
-/**
- * Erstellt eine temporäre JSON-Datei mit dem gegebenen Inhalt
- * und gibt den absoluten Pfad zurück.
- */
-export function makeJsonFile(fileName: string, jsonValue: unknown): string {
-  const temporaryDirectory = mkdtempSync(join(tmpdir(), 'dqat-json-'));
-  const fullPath = join(temporaryDirectory, fileName);
-  writeFileSync(fullPath, JSON.stringify(jsonValue), { encoding: 'utf-8' });
-  return fullPath;
-}
+const JSON_TEMP_PATH = 'dqat-json-file-provider' as const;
 
 describe('JsonFileProvider', () => {
   describe('Basics', () => {
     it('setzt den Default-Namen auf "json"', () => {
-      const filePath = makeJsonFile('config.json', { app: { name: 'dqat' } });
+      const filePath = makeJsonFile('config.json', JSON_TEMP_PATH, {
+        app: { name: 'dqat' },
+      });
       const provider = new JsonFileProvider(filePath);
       expect(provider.name).toBe('json');
     });
 
     it('akzeptiert einen benutzerdefinierten Namen', () => {
-      const filePath = makeJsonFile('config.json', {
+      const filePath = makeJsonFile('config.json', JSON_TEMP_PATH, {
         feature: { enabled: true },
       });
       const provider = new JsonFileProvider(filePath, { name: 'config' });
@@ -32,7 +26,9 @@ describe('JsonFileProvider', () => {
     });
 
     it('liefert für unbekannte Keys undefined zurück', () => {
-      const filePath = makeJsonFile('config.json', { foo: 'bar' });
+      const filePath = makeJsonFile('config.json', JSON_TEMP_PATH, {
+        foo: 'bar',
+      });
       const provider = new JsonFileProvider(filePath);
       expect(provider.get('no.such.key')).toBeUndefined();
     });
@@ -53,20 +49,22 @@ describe('JsonFileProvider', () => {
     });
 
     it('wirft bei ungültigem JSON eine klare Fehlermeldung', () => {
-      const filePath = makeJsonFile('broken.json', { ok: true });
+      const filePath = makeJsonFile('broken.json', JSON_TEMP_PATH, {
+        ok: true,
+      });
       writeFileSync(filePath, '{ invalid', { encoding: 'utf-8' }); // Datei „kaputt“ schreiben
       expect(() => new JsonFileProvider(filePath)).toThrow(/Ungültiges JSON/);
     });
 
     it('wirft, wenn das Root kein Plain Object ist (z. B. Array)', () => {
-      const filePath = makeJsonFile('array.json', [1, 2, 3]);
+      const filePath = makeJsonFile('array.json', JSON_TEMP_PATH, [1, 2, 3]);
       expect(() => new JsonFileProvider(filePath)).toThrow(/kein JSON-Objekt/);
     });
   });
 
   describe('JsonFileProvider > Flatten (dot-Notation)', () => {
     it('flacht verschachtelte Objekte zu dot-Keys ab', () => {
-      const filePath = makeJsonFile('deep.json', {
+      const filePath = makeJsonFile('deep.json', JSON_TEMP_PATH, {
         db: { host: 'localhost', port: 3306, options: { ssl: false } },
       });
       const provider = new JsonFileProvider(filePath);
@@ -79,7 +77,9 @@ describe('JsonFileProvider', () => {
     });
 
     it('behandelt Arrays als Blattwerte', () => {
-      const filePath = makeJsonFile('arr.json', { list: { items: [1, 2, 3] } });
+      const filePath = makeJsonFile('arr.json', JSON_TEMP_PATH, {
+        list: { items: [1, 2, 3] },
+      });
       const provider = new JsonFileProvider(filePath);
 
       expect(provider.list('list.items')).toEqual({
@@ -92,7 +92,7 @@ describe('JsonFileProvider', () => {
 
   describe('Prefix-Filter & Separator', () => {
     it('filtert per Prefix: exakter Key', () => {
-      const filePath = makeJsonFile('prefix.json', {
+      const filePath = makeJsonFile('prefix.json', JSON_TEMP_PATH, {
         app: { name: 'dqat', cfg: { mode: 'prod' } },
       });
       const provider = new JsonFileProvider(filePath);
@@ -101,7 +101,7 @@ describe('JsonFileProvider', () => {
     });
 
     it('filtert per Prefix: Prefix + Separator', () => {
-      const filePath = makeJsonFile('prefix2.json', {
+      const filePath = makeJsonFile('prefix2.json', JSON_TEMP_PATH, {
         app: { name: 'dqat', cfg: { mode: 'prod' } },
       });
       const provider = new JsonFileProvider(filePath);
@@ -113,7 +113,9 @@ describe('JsonFileProvider', () => {
     });
 
     it('unterstützt einen benutzerdefinierten Separator ("/")', () => {
-      const filePath = makeJsonFile('sep.json', { a: { b: { c: 1 } } });
+      const filePath = makeJsonFile('sep.json', JSON_TEMP_PATH, {
+        a: { b: { c: 1 } },
+      });
       const provider = new JsonFileProvider(filePath, { separator: '/' });
 
       expect(provider.list('a/b')).toEqual({ 'a/b/c': 1 });
@@ -122,7 +124,9 @@ describe('JsonFileProvider', () => {
 
   describe('Immutability & Safety', () => {
     it('gibt via list() ein eingefrorenes Objekt zurück (immutable)', () => {
-      const filePath = makeJsonFile('immutable.json', { x: { y: 1 } });
+      const filePath = makeJsonFile('immutable.json', JSON_TEMP_PATH, {
+        x: { y: 1 },
+      });
       const provider = new JsonFileProvider(filePath);
 
       const allEntries = provider.list();
@@ -130,7 +134,7 @@ describe('JsonFileProvider', () => {
     });
 
     it('liefert get() für bekannte Keys korrekt aufgelöste Werte', () => {
-      const filePath = makeJsonFile('values.json', {
+      const filePath = makeJsonFile('values.json', JSON_TEMP_PATH, {
         clock: { offsetMs: 500 },
       });
       const provider = new JsonFileProvider(filePath);

--- a/test/unit/factory/provider/memoryProvider.spec.ts
+++ b/test/unit/factory/provider/memoryProvider.spec.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { MemoryProvider } from '../../../../src/factory/provider/memoryProvider.ts';
-import type { MemoryProviderOptions } from '../../../../src/type/provider/providerOptions.ts';
+import type { IMemoryProviderOptions } from '../../../../src/type/provider/providerOptions.ts';
 
-const make = (input: unknown, opts?: MemoryProviderOptions): MemoryProvider =>
+const make = (input: unknown, opts?: IMemoryProviderOptions): MemoryProvider =>
   new MemoryProvider(input as Record<string, unknown>, opts);
+
+const FEATURE_ENABLED = 'feature.enabled';
 
 describe('MemoryProvider', () => {
   describe('Basics', () => {
@@ -26,6 +28,97 @@ describe('MemoryProvider', () => {
       listed1.a = 999 as unknown as never;
       const listed2 = provider.list();
       expect(listed2).toEqual({ a: 1, b: 2 });
+    });
+  });
+
+  describe('set', () => {
+    it('setzt einen neuen Key, der anschließend mit get gelesen werden kann', () => {
+      const provider = make({}, { flatten: false });
+
+      provider.set(FEATURE_ENABLED, true);
+
+      expect(provider.get(FEATURE_ENABLED)).toBe(true);
+    });
+
+    it('überschreibt einen bestehenden Key', () => {
+      const provider = make({ 'feature.enabled': false }, { flatten: false });
+
+      provider.set(FEATURE_ENABLED, true);
+
+      expect(provider.get(FEATURE_ENABLED)).toBe(true);
+    });
+
+    it('list enthält einen neu gesetzten Key', () => {
+      const provider = make({}, { flatten: false });
+
+      provider.set('api.baseUrl', 'https://example.test');
+
+      expect(provider.list()).toEqual({
+        'api.baseUrl': 'https://example.test',
+      });
+    });
+
+    it('list(prefix) filtert nach gesetzten Werten weiterhin korrekt', () => {
+      const provider = make({}, { flatten: false });
+
+      provider.set('db.host', 'localhost');
+      provider.set('db.port', 3306);
+      provider.set('api.url', 'https://example.test');
+
+      expect(provider.list('db')).toEqual({
+        'db.host': 'localhost',
+        'db.port': 3306,
+      });
+    });
+
+    it('verhält sich bei überschriebenen Werten konsistent mit der bisherigen Provider-Logik', () => {
+      const provider = make(
+        { 'feature.enabled': false, 'feature.name': 'alpha' },
+        { flatten: false },
+      );
+
+      provider.set(FEATURE_ENABLED, true);
+
+      expect(provider.get(FEATURE_ENABLED)).toBe(true);
+      expect(provider.list()).toEqual({
+        'feature.enabled': true,
+        'feature.name': 'alpha',
+      });
+    });
+
+    it('entfernt einen Key bei undefined, wenn dropUndefined aktiv ist', () => {
+      const provider = make(
+        { 'feature.enabled': true },
+        { flatten: false, dropUndefined: true },
+      );
+
+      provider.set(FEATURE_ENABLED, undefined);
+
+      expect(provider.get(FEATURE_ENABLED)).toBeUndefined();
+      expect(provider.list()).toEqual({});
+    });
+
+    it('behält undefined bei, wenn dropUndefined deaktiviert ist', () => {
+      const provider = make(
+        { 'feature.enabled': true },
+        { flatten: false, dropUndefined: false },
+      );
+
+      provider.set(FEATURE_ENABLED, undefined);
+
+      const listed = provider.list();
+
+      expect(Object.hasOwn(listed, FEATURE_ENABLED)).toBeTruthy();
+      expect(listed[FEATURE_ENABLED]).toBeUndefined();
+    });
+
+    it('speichert Funktionswerte nicht', () => {
+      const provider = make({ 'feature.enabled': true }, { flatten: false });
+
+      provider.set(FEATURE_ENABLED, () => true);
+
+      expect(provider.get(FEATURE_ENABLED)).toBeUndefined();
+      expect(provider.list()).toEqual({});
     });
   });
 

--- a/test/unit/holodeck/engine/HolodeckEmbeddedEngineAdapter.spec.ts
+++ b/test/unit/holodeck/engine/HolodeckEmbeddedEngineAdapter.spec.ts
@@ -40,6 +40,7 @@ describe('HolodeckEmbeddedEngineAdapter', () => {
       serverPort: 1080,
       trace: true,
       verbose: true,
+      jvmOptions: ['-Dmockserver.disableSystemOut=true'],
     });
   });
 

--- a/test/unit/holodeck/sceneLoader.spec.ts
+++ b/test/unit/holodeck/sceneLoader.spec.ts
@@ -10,7 +10,7 @@
  * - delayMs wird korrekt nach number gecastet
  */
 
-import Ajv2020 from 'ajv/dist/2020';
+import Ajv2020 from 'ajv/dist/2020.js';
 import { describe, expect, it } from 'vitest';
 import { HolodeckSceneLoadError } from '../../../src/holodeck/holodeck.error.ts';
 import { SceneLoader } from '../../../src/holodeck/sceneLoader.ts';

--- a/test/unit/util/provider/optionNormalization.spec.ts
+++ b/test/unit/util/provider/optionNormalization.spec.ts
@@ -1,8 +1,17 @@
 import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_DOUBLE_UNDERSCORE_IS_SEPARATOR,
+  DEFAULT_DROP_UNDEFINED,
+  DEFAULT_ENV_PARSE,
+  DEFAULT_FLATTEN,
+  DEFAULT_INCLUDE_ARRAY_INDICES,
+  DEFAULT_SEPARATOR,
+  DEFAULT_TO_LOWER_CASE,
+} from '../../../../src/config/starfleetDirectives.config.ts';
 import type {
-  EnvProviderOptions,
-  JsonFileProviderOptions,
-  MemoryProviderOptions,
+  IEnvProviderOptions,
+  IJsonFileProviderOptions,
+  IMemoryProviderOptions,
   NormalizedEnvOptions,
   NormalizedJsonFileOptions,
   NormalizedMemoryOptions,
@@ -12,20 +21,11 @@ import {
   normalizeJsonFileOptions,
   normalizeMemoryOptions,
 } from '../../../../src/util/provider/optionNormalization.ts';
-import {
-  DEFAULT_DOUBLE_UNDERSCORE_IS_SEPARATOR,
-  DEFAULT_DROP_UNDEFINED,
-  DEFAULT_ENV_PARSE,
-  DEFAULT_FLATTEN,
-  DEFAULT_INCLUDE_ARRAY_INDICES,
-  DEFAULT_SEPARATOR,
-  DEFAULT_TO_LOWER_CASE,
-} from '../../../../src/util/provider/providerDefaults.ts';
 
 describe('optionNormalization Hilfsfunktionen', () => {
   describe('normalizeEnvOptions', () => {
     const tests: ReadonlyArray<
-      [string, EnvProviderOptions | undefined, NormalizedEnvOptions]
+      [string, IEnvProviderOptions | undefined, NormalizedEnvOptions]
     > = [
       [
         'alle Werte standardmäßig gesetzt werden, wenn kein Input vorhanden ist',
@@ -117,7 +117,7 @@ describe('optionNormalization Hilfsfunktionen', () => {
     it.for(tests)(
       'liefert korrekt normalisierte Optionen, wenn %s',
       ([, input, expected]) => {
-        const result = normalizeEnvOptions(input as EnvProviderOptions);
+        const result = normalizeEnvOptions(input as IEnvProviderOptions);
         expect(result).toEqual(expected);
       },
     );
@@ -125,7 +125,7 @@ describe('optionNormalization Hilfsfunktionen', () => {
 
   describe('normalizeJsonFileOptions', () => {
     const tests: ReadonlyArray<
-      [string, JsonFileProviderOptions | undefined, NormalizedJsonFileOptions]
+      [string, IJsonFileProviderOptions | undefined, NormalizedJsonFileOptions]
     > = [
       [
         'explizite Werte korrekt übernommen werden',
@@ -189,7 +189,7 @@ describe('optionNormalization Hilfsfunktionen', () => {
       'liefert korrekt normalisierte Optionen, wenn %s',
       ([, input, expected]) => {
         const result = normalizeJsonFileOptions(
-          input as JsonFileProviderOptions,
+          input as IJsonFileProviderOptions,
         );
         expect(result).toEqual(expected);
       },
@@ -198,7 +198,7 @@ describe('optionNormalization Hilfsfunktionen', () => {
 
   describe('normalizeMemoryOptions', () => {
     const tests: ReadonlyArray<
-      [string, MemoryProviderOptions | undefined, NormalizedMemoryOptions]
+      [string, IMemoryProviderOptions | undefined, NormalizedMemoryOptions]
     > = [
       [
         'explizite Werte korrekt übernommen werden',
@@ -283,7 +283,7 @@ describe('optionNormalization Hilfsfunktionen', () => {
     it.for(tests)(
       'liefert korrekt normalisierte Optionen, wenn %s',
       ([, input, expected]) => {
-        const result = normalizeMemoryOptions(input as MemoryProviderOptions);
+        const result = normalizeMemoryOptions(input as IMemoryProviderOptions);
         expect(result).toEqual(expected);
       },
     );

--- a/test/util/jsonFileProvider.helper.ts
+++ b/test/util/jsonFileProvider.helper.ts
@@ -1,0 +1,24 @@
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+
+/**
+ * Erstellt eine temporäre JSON-Datei mit dem gegebenen Inhalt
+ * und gibt den absoluten Pfad zurück.
+ */
+export function makeJsonFile(
+  fileName: string,
+  tempPath: string,
+  jsonValue: unknown,
+): string {
+  const temporaryDirectory = mkdtempSync(join(tmpdir(), tempPath));
+  const fullPath = join(temporaryDirectory, fileName);
+
+  const path = dirname(fullPath);
+  if (!existsSync(path)) {
+    mkdirSync(path, { recursive: true });
+  }
+
+  writeFileSync(fullPath, JSON.stringify(jsonValue), { encoding: 'utf-8' });
+  return fullPath;
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.framework.json",
   "compilerOptions": {
     "noEmit": true,
-    "baseUrl": ".",
     "rootDir": "."
   },
   "include": [

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,7 +1,9 @@
 {
   "extends": "./tsconfig.framework.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "baseUrl": ".",
+    "rootDir": "."
   },
   "include": [
     "src/**/*",

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.framework.json",
   "compilerOptions": {
     "noEmit": true
   },

--- a/tsconfig.framework.json
+++ b/tsconfig.framework.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "rootDir": "src",
+    "baseUrl": ".",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "paths": {
+      "#callback": ["src/callback/index.ts"],
+      "#setup": ["src/setup/index.ts"]
+    }
+  },
+  "include": ["src"],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "test",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "features"
+  ]
+}

--- a/tsconfig.framework.json
+++ b/tsconfig.framework.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022"],
+    "types": ["node"],
     "module": "esnext",
     "moduleResolution": "bundler",
     "rootDir": "src",
@@ -24,7 +25,8 @@
       "@RMajewski/dqat-core": ["./src/index.ts"],
       "@RMajewski/dqat-core/*": ["./src/*"],
       "#callback": ["./src/callback/index.ts"],
-      "#setup": ["./src/setup/index.ts"]
+      "#setup": ["./src/setup/index.ts"],
+      "#util": ["./src/util/index.ts"]
     }
   },
   "include": ["src"],

--- a/tsconfig.framework.json
+++ b/tsconfig.framework.json
@@ -2,10 +2,9 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022"],
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "rootDir": "src",
-    "baseUrl": ".",
     "outDir": "dist",
     "declaration": true,
     "declarationMap": true,
@@ -22,10 +21,10 @@
     "allowImportingTsExtensions": true,
     "noEmit": true,
     "paths": {
-      "@RMajewski/dqat-core": ["src/index.ts"],
-      "@RMajewski/dqat-core/*": ["src/*"],
-      "#callback": ["src/callback/index.ts"],
-      "#setup": ["src/setup/index.ts"]
+      "@RMajewski/dqat-core": ["./src/index.ts"],
+      "@RMajewski/dqat-core/*": ["./src/*"],
+      "#callback": ["./src/callback/index.ts"],
+      "#setup": ["./src/setup/index.ts"]
     }
   },
   "include": ["src"],

--- a/tsconfig.framework.json
+++ b/tsconfig.framework.json
@@ -22,6 +22,8 @@
     "allowImportingTsExtensions": true,
     "noEmit": true,
     "paths": {
+      "@RMajewski/dqat-core": ["src/index.ts"],
+      "@RMajewski/dqat-core/*": ["src/*"],
       "#callback": ["src/callback/index.ts"],
       "#setup": ["src/setup/index.ts"]
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,38 +1,8 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "lib": ["ES2022"],
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "rootDir": "src",
-    "baseUrl": ".",
-    "outDir": "dist",
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "strict": true,
-    "noImplicitAny": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": false,
-    "noFallthroughCasesInSwitch": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "allowImportingTsExtensions": true,
-    "noEmit": true,
-    "paths": {
-      "#callback": ["src/callback/index.ts"],
-      "#setup": ["src/setup/index.ts"]
-    }
-  },
-  "include": ["src"],
-  "exclude": [
-    "dist",
-    "node_modules",
-    "test",
-    "**/*.test.ts",
-    "**/*.spec.ts",
-    "features"
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.framework.json" },
+    { "path": "./tsconfig.test.json" },
+    { "path": "./tsconfig.eslint.json" }
   ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,10 +1,10 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.framework.json",
   "compilerOptions": {
     "noEmit": true,
     "types": ["vitest", "vitest/importMeta", "node"],
     "rootDir": "."
   },
-  "include": ["test/unit/**/*.spec.ts"],
+  "include": ["test/**/*.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -5,6 +5,6 @@
     "types": ["vitest", "vitest/importMeta", "node"],
     "rootDir": "."
   },
-  "include": ["test/**/*.ts"],
+  "include": ["test/**/*.ts", "src/**/*.d.ts"],
   "exclude": ["dist", "node_modules"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     'src/callback/index.ts',
     'src/setup/index.ts',
     'src/step/index.ts',
+    'src/util/index.ts',
   ],
   format: ['esm', 'cjs'],
   dts: true,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -17,4 +17,5 @@ export default defineConfig({
   target: 'node22',
   treeshake: true,
   skipNodeModulesBundle: true,
+  tsconfig: './tsconfig.framework.json',
 });


### PR DESCRIPTION
### 🚀 feat
- [565cf2a](../../commit/565cf2af6117b9f1b8f76caaf9fffeeb9abf313e) feat(utils): Add isStarfleetDirectiveKey
- [85c1228](../../commit/85c12285531566371633986c82a46cbaaa31271c) feat(holodeck): Holodeck-Start und Szenenladen implementieren
- [db2d7a6](../../commit/db2d7a66cc8a540dc7a77d98b9b42be2cf4740da) feat(core): EnvProviderOptions rekonstruieren und MemoryProvider um set erweitern
- [50d5dd1](../../commit/50d5dd1b8792b9c6b913884786abcbf8fe7daf7f) feat(holodeck): MockServer-System-Output deaktiviert und Logs als Dateien gespeichert
- [dc0ea5c](../../commit/dc0ea5cab4f15ca18eac5297f7a06ae990041e5b) feat(starfleet-directives): Env-Provider-Optionen beim Laden der Directives verfügbar machen

### 🐛 fix
_none_

### ♻️ refactor
- [e18fdc3](../../commit/e18fdc3569d61a07664fcae8e1fa9fedcc88a244) refactor(core): Interfaces mit I-Präfix versehen und Default-Konstanten zentralisiert

### 📝 docs
_none_

### ✅ test
- [6b51da4](../../commit/6b51da4b9cd4252767630222767239ac92414070) test(acceptance): Schritte zur Überprüfung der Provider-Priorität ergänzt
- [276e6af](../../commit/276e6afb746814b33dfa9bdd314c18ac4be2ca02) test(starfleet-directives): Akzeptanztests für StarfleetDirectives-Ladevorgang vervollständigt
- [41e9597](../../commit/41e95976c5c3a5e91448cc127d707b0b101d4254) test(ci): noch nicht lauffähige Akzeptanztests in der Pipeline deaktiviert

### 🔧 ci
_none_

### 🧹 chore
- [4317bb3](../../commit/4317bb3ebb97a446fb2d4f1529352f7547870ea6) chore: tsconfig-Struktur für IDE-, Test- und Lint-Kompatibilität bereinigt
- [b210536](../../commit/b210536a8613cd3fa1db82112dbdf6e0dd60574e) chore(utils): Add entry point for utils
- [d2b3178](../../commit/d2b31789010c98bfaa823836c6c9e7be597937fd) chore: JSON-Schema-Validierung für Holodeck-Scenes in ESLint und VSCode integriert
- [d20eb32](../../commit/d20eb32b4c1ead7f2e09562e907512c009216b9b) chore: merge branch 'alpha' into feature/M1
- [03cce62](../../commit/03cce626dc61a6c9b68f5c08e28cae4cecd21809) chore(feature): Format für Feature-Dateien richtig gesetzt.
- [d60aed5](../../commit/d60aed52f468fc015563157e0856d3ed1116d38a) chore: .gitignore geändert.
- [87acd90](../../commit/87acd908d0f8b5ea0abd0c51401891cb2e8d26af) chore(changelog): Format für "CHANGELOG.md" angepasst
- [fdb75cd](../../commit/fdb75cddaf3564e261872d1dfe4683eea139cf6e) chore(tsconfig): Entferne deprecated Optionen und modernisiere Modulauflösung
- [c175185](../../commit/c175185993e9134dbec5e95787d761906f349cd8) chore(pnpm): nutzt jetzt pnpm-Version 10.33.0
- [495f5c6](../../commit/495f5c68256029a0ae7fe474c04a1b2cbc137702) chore(tsconfig): Stelle Node-Typen korrekt für TypeScript bereit
- [ac0f38d](../../commit/ac0f38df24aaad0d24910923a9db94c112aff289) chore(ci): CI-Konfiguration für Akzeptanztests und Script ergänzt
- [7c1dfdc](../../commit/7c1dfdc814e870b42096e67d6f84e3bad0183c01) chore(ci): Anpassung der Unit-Tests und Integration der Akzeptanztests in Tuvok

### 🚧 wip
- [d992a4f](../../commit/d992a4fc4a81d1a088c04cc497dbc1c547e5524c) wip(holodeck): Vorbereitung der ersten Cucumber-Akzeptanztests für Holodeck und generische Endpoint-Callbacks

### 📦 Other
_none_