### PR TITLE
Feature/holodeck scene load body file

### DIFF
--- a/src/callback/endpoint.ts
+++ b/src/callback/endpoint.ts
@@ -122,3 +122,56 @@ export function expectLastResponseStatusCallback(
     );
   }
 }
+
+/**
+ * Prüft, ob der zuletzt empfangene HTTP-Response-Body einen bestimmten Text enthält.
+ *
+ * Der Body wird dabei als reiner String betrachtet. Es findet keine
+ * Interpretation als JSON oder HTML statt. Dadurch bleibt der Schritt
+ * bewusst generisch und unabhängig von einer konkreten Darstellungsschicht.
+ *
+ * Voraussetzung:
+ * - Vorher muss ein Request über einen Schritt wie
+ *   `Wenn ich den Endpunkt "...“ über GET abrufe`
+ *   ausgeführt worden sein.
+ * - Das Ergebnis muss in `this.lastResponse` gespeichert sein.
+ *
+ * Typischer Gherkin-Schritt:
+ *
+ *   Und der Response-Body enthält "<h1>Schwarze Wegameise</h1>"
+ *
+ * @example
+ * Gherkin (Feature-Datei, deutsch):
+ *   Wenn ich den Endpunkt "/api/status" über GET abrufe
+ *   Dann erwarte ich den HTTP-Statuscode 200
+ *   Und der Response-Body enthält "<h1>Schwarze Wegameise</h1>"
+ *
+ * @param this DqatWorld – Gemeinsamer Szenario-Kontext.
+ * @param expectedContent string – Erwarteter Teilstring, der im Response-Body enthalten sein soll.
+ *
+ * @throws Error
+ * Wird ausgelöst, wenn kein vorheriger Response vorhanden ist oder
+ * der erwartete Inhalt nicht gefunden wird.
+ */
+export function responseBodyContainsCallback(
+  this: DqatWorld,
+  expectedContent: string,
+): void {
+  if (!this.lastResponse) {
+    throw new Error(
+      'Es liegt keine letzte Response vor, die geprüft werden kann.',
+    );
+  }
+
+  const { bodyText } = this.lastResponse;
+
+  if (!bodyText.includes(expectedContent)) {
+    throw new Error(
+      [
+        'Der Response-Body enthält den erwarteten Inhalt nicht.',
+        `Erwartet: ${expectedContent}`,
+        `Tatsächlicher Body: ${bodyText}`,
+      ].join('\n'),
+    );
+  }
+}

--- a/src/callback/holodeck.ts
+++ b/src/callback/holodeck.ts
@@ -1,12 +1,10 @@
 import Ajv2020 from 'ajv/dist/2020.js';
-import { readFile } from 'node:fs/promises';
-import path from 'node:path';
-import { HolodeckSceneLoadError } from '../holodeck/holodeck.error.ts';
+import { resolve } from 'node:path';
 import { Holodeck } from '../holodeck/holodeck.ts';
 import { SceneLoader } from '../holodeck/sceneLoader.ts';
 import type { DqatWorld } from '../setup/DqatWorld.ts';
-import { HolodeckSceneLoadErrorCode } from '../type/holodeck/holodeck.error.ts';
-import type { HolodeckSceneDocument } from '../type/holodeck/sceneDocument.ts';
+import { readBodyFileContent } from '../util/holodeck/readBodyFile.ts';
+import { readSceneDocumentByName } from '../util/holodeck/readScene.ts';
 import { shutdownHolodeckWithLogs } from '../util/holodeck/shutdown.ts';
 
 /**
@@ -51,44 +49,15 @@ export async function startHolodeckCallback(
 
   const fixturesDir =
     this.get<string>('holodeck.fixturesDir') ??
-    path.resolve(process.cwd(), 'test/acceptance/fixtures/holodeck');
+    resolve(process.cwd(), 'test/acceptance/fixtures/holodeck');
 
   const sceneLoader = new SceneLoader({
-    readSceneDocumentByName: async (
-      sceneName: string,
-    ): Promise<HolodeckSceneDocument> => {
-      const sceneFilePath = path.join(fixturesDir, `${sceneName}.scene.json`);
+    readSceneDocumentByName: (sceneName) =>
+      readSceneDocumentByName(fixturesDir, sceneName),
 
-      let documentText: string;
-      try {
-        documentText = await readFile(sceneFilePath, 'utf8');
-      } catch (error) {
-        const isMissingFile =
-          typeof error === 'object' &&
-          error !== null &&
-          'code' in error &&
-          (error as { code?: string }).code === 'ENOENT';
+    readBodyFileContent: (bodyFilePath) =>
+      readBodyFileContent(fixturesDir, bodyFilePath),
 
-        if (isMissingFile) {
-          throw new HolodeckSceneLoadError({
-            code: HolodeckSceneLoadErrorCode.UNKNOWN_SCENE,
-            message: `Scene "${sceneName}" not found in ${fixturesDir}`,
-            path: 'scene',
-          });
-        }
-        throw error;
-      }
-
-      try {
-        return JSON.parse(documentText) as HolodeckSceneDocument;
-      } catch {
-        throw new HolodeckSceneLoadError({
-          code: HolodeckSceneLoadErrorCode.SCHEMA_VIOLATION,
-          message: `Scene "${sceneName}" contains invalid JSON`,
-          path: sceneFilePath,
-        });
-      }
-    },
     nowProvider: () => this.now(),
     ajvInstance: new Ajv2020({
       allErrors: true,

--- a/src/eslint/schemas/holodeck.scene.v1.json
+++ b/src/eslint/schemas/holodeck.scene.v1.json
@@ -76,6 +76,23 @@
           "response": {
             "type": "object",
             "required": ["statusCode"],
+            "oneOf": [
+              {
+                "required": ["body"],
+                "properties": {
+                  "body": {}
+                }
+              },
+              {
+                "required": ["bodyFile"],
+                "properties": {
+                  "bodyFile": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              }
+            ],
             "additionalProperties": false,
             "properties": {
               "statusCode": {
@@ -88,6 +105,10 @@
                 "additionalProperties": { "type": "string" }
               },
               "body": {},
+              "bodyFile": {
+                "type": "string",
+                "minLength": 1
+              },
               "delayMs": {
                 "oneOf": [
                   { "type": "integer", "minimum": 0 },

--- a/src/holodeck/sceneLoader.ts
+++ b/src/holodeck/sceneLoader.ts
@@ -28,11 +28,13 @@ type TemplateChunk =
  */
 export class SceneLoader {
   private readonly readSceneDocumentByName: SceneLoaderConfig['readSceneDocumentByName'];
+  private readonly readBodyFileContent: SceneLoaderConfig['readBodyFileContent'];
   private readonly nowProvider: SceneLoaderConfig['nowProvider'];
   private readonly validateSceneDocument: (data: unknown) => boolean;
 
   constructor(config: SceneLoaderConfig) {
     this.readSceneDocumentByName = config.readSceneDocumentByName;
+    this.readBodyFileContent = config.readBodyFileContent;
     this.nowProvider = config.nowProvider;
     const validateFn = config.ajvInstance.compile(holodeckSceneSchema);
     this.validateSceneDocument = validateFn;
@@ -73,9 +75,19 @@ export class SceneLoader {
 
     // 3. Templates in allen Routen rendern
     const renderedRoutes: LoadedHolodeckScene['routes'] =
-      sceneDocument.routes.map((route, index) =>
-        this.renderRoute(route, index, now, resolvedVariables),
-      );
+      sceneDocument.routes.map((route, index) => {
+        const routeWithResolvedBodyFile = this.resolveRouteBodyFile(
+          route,
+          index,
+        );
+
+        return this.renderRoute(
+          routeWithResolvedBodyFile,
+          index,
+          now,
+          resolvedVariables,
+        );
+      });
 
     // 4. Vollständig gerenderte Szene zurückgeben
     return {
@@ -85,6 +97,63 @@ export class SceneLoader {
       meta: sceneDocument.meta,
       routes: renderedRoutes,
     };
+  }
+
+  /**
+   * Löst einen optionalen `response.bodyFile` auf und ersetzt ihn durch einen geladenen `response.body`.
+   *
+   * Wenn in der Route ein `bodyFile` definiert ist, wird der Dateiinhalt über
+   * `readBodyFileContent` geladen und als `response.body` gesetzt.
+   *
+   * Der ursprüngliche `bodyFile` wird dabei entfernt, da die nachfolgenden Schritte
+   * ausschließlich mit dem finalen `body` arbeiten.
+   *
+   * Diese Methode kümmert sich ausschließlich um das Laden des Body-Inhalts aus dem
+   * Dateisystem und trifft keine Entscheidungen zur Template-Verarbeitung.
+   * Das Rendering von Template-Variablen erfolgt später in `renderRoute`.
+   *
+   * @param route - Die zu verarbeitende Route aus dem Scene-Dokument.
+   * @param routeIndex - Index der Route innerhalb des Scene-Dokuments.
+   * @returns Eine neue Route, bei der `bodyFile` durch `body` ersetzt wurde, sofern vorhanden.
+   *
+   * @throws {HolodeckSceneLoadError}
+   * Wird ausgelöst, wenn die Datei nicht geladen werden kann
+   * (z. B. Datei nicht gefunden oder nicht lesbar).
+   */
+  resolveRouteBodyFile(
+    route: HolodeckRouteSpec,
+    routeIndex: number,
+  ): HolodeckRouteSpec {
+    const response = route.response;
+    const bodyFile = response.bodyFile;
+
+    if (!bodyFile) {
+      return route;
+    }
+
+    try {
+      const fileContent = this.readBodyFileContent(bodyFile);
+
+      return {
+        ...route,
+        response: {
+          ...response,
+          body: fileContent,
+          bodyFile: undefined,
+        },
+      };
+    } catch (error) {
+      if (error instanceof HolodeckSceneLoadError) {
+        throw error;
+      }
+
+      throw new HolodeckSceneLoadError({
+        code: HolodeckSceneLoadErrorCode.FILESYSTEM_ERROR,
+        message: `Failed to read body file: ${response.bodyFile}`,
+        path: `routes[${routeIndex}].response.bodyFile`,
+        received: response.bodyFile,
+      });
+    }
   }
 
   /**

--- a/src/step/endpoint.steps.ts
+++ b/src/step/endpoint.steps.ts
@@ -2,8 +2,11 @@ import { Then, When } from '@cucumber/cucumber';
 import {
   expectLastResponseStatusCallback,
   fetchRequestCallback,
+  responseBodyContainsCallback,
 } from '../callback/endpoint.ts';
 
 When('ich den Endpunkt {string} über {word} abrufe', fetchRequestCallback);
 
 Then('erwarte ich den HTTP-Statuscode {int}', expectLastResponseStatusCallback);
+
+Then('der Response-Body enthält {string}', responseBodyContainsCallback);

--- a/src/type/holodeck/holodeck.error.ts
+++ b/src/type/holodeck/holodeck.error.ts
@@ -48,6 +48,19 @@ export enum HolodeckSceneLoadErrorCode {
    * Fehler aus der Mock-Engine oder einer anderen technischen Quelle.
    */
   ENGINE_ERROR = 'engineError',
+
+  /**
+   * Fehler beim Zugriff auf das Dateisystem, z. B. beim Laden von `bodyFile`.
+   *
+   * Dieser Fehler tritt auf, wenn die Szene zwar gültig ist, aber externe Ressourcen
+   * nicht geladen werden können. Typische Ursachen sind:
+   *
+   * - Die angegebene Datei existiert nicht.
+   * - Der Pfad liegt außerhalb des erlaubten `holodeck.fixturesDir`.
+   * - Die Datei kann nicht gelesen werden (z. B. fehlende Berechtigungen).
+   * - Der angegebene Pfad ist ungültig oder nicht auflösbar.
+   */
+  FILESYSTEM_ERROR = 'filesystemError',
 }
 
 /**

--- a/src/type/holodeck/request.ts
+++ b/src/type/holodeck/request.ts
@@ -93,6 +93,24 @@ export interface HolodeckResponseSpec {
   body?: unknown;
 
   /**
+   * Dateiverweis für den Antwort-Body.
+   *
+   * Wenn gesetzt, wird der Inhalt der angegebenen Datei geladen
+   * und als `response.body` verwendet.
+   *
+   * Der Pfad wird relativ zu `holodeck.fixturesDir` aufgelöst.
+   * Unterverzeichnisse sind erlaubt (z. B. "html/test1.html").
+   *
+   * Der geladene Inhalt darf ebenfalls Template-Strings enthalten
+   * und wird durch den SceneLoader gerendert.
+   *
+   * Hinweis:
+   * - Es muss entweder `body` oder `bodyFile` gesetzt sein.
+   * - Beide gleichzeitig sind nicht erlaubt (Schema-Validierung).
+   */
+  bodyFile?: string;
+
+  /**
    * Künstliche Verzögerung in Millisekunden.
    *
    * Im rohen Dokument (SceneDocument):

--- a/src/type/holodeck/sceneLoaderConfig.ts
+++ b/src/type/holodeck/sceneLoaderConfig.ts
@@ -29,6 +29,18 @@ export interface SceneLoaderConfig {
   ) => Promise<HolodeckSceneDocument>;
 
   /**
+   * Lädt den Inhalt einer Body-Datei synchron.
+   *
+   * Der übergebene Pfad stammt aus `response.bodyFile` und wird von der
+   * konkreten Implementierung relativ zu `holodeck.fixturesDir` aufgelöst.
+   *
+   * Die Methode arbeitet bewusst synchron, damit der Cucumber-JS-Lifecycle
+   * nicht durch vergessene `await`-Aufrufe oder verzögerte Dateizugriffe
+   * instabil werden kann.
+   */
+  readBodyFileContent: (bodyFilePath: string) => string;
+
+  /**
    * Liefert die aktuelle Zeit als Date-Objekt.
    * Diese Zeitquelle wird für die Templates {{now}} und {{nowEpochMs}} verwendet.
    *

--- a/src/util/holodeck/readBodyFile.ts
+++ b/src/util/holodeck/readBodyFile.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { HolodeckSceneLoadError } from '../../holodeck/holodeck.error.ts';
+import { HolodeckSceneLoadErrorCode } from '../../type/holodeck/holodeck.error.ts';
+
+/**
+ * Lädt den Inhalt einer Body-Datei synchron aus dem Dateisystem.
+ *
+ * Der Pfad wird relativ zu `fixturesDir` aufgelöst.
+ *
+ * Sicherheitsregel:
+ * - Der finale Pfad muss innerhalb von `fixturesDir` liegen.
+ *
+ * Fehlerbehandlung:
+ * - Datei nicht gefunden / nicht lesbar → FILESYSTEM_ERROR
+ *
+ * @param fixturesDir - Basisverzeichnis für Holodeck-Fixtures.
+ * @param bodyFilePath - Relativer Pfad zur Body-Datei (z. B. "html/test1.html").
+ * @returns Inhalt der Datei als String.
+ */
+export function readBodyFileContent(
+  fixturesDir: string,
+  bodyFilePath: string,
+): string {
+  const resolvedPath = resolve(fixturesDir, bodyFilePath);
+
+  if (!resolvedPath.startsWith(resolve(fixturesDir))) {
+    throw new HolodeckSceneLoadError({
+      code: HolodeckSceneLoadErrorCode.FILESYSTEM_ERROR,
+      message: `Invalid bodyFile path: ${bodyFilePath}`,
+      path: 'response.bodyFile',
+      received: bodyFilePath,
+    });
+  }
+
+  try {
+    return readFileSync(resolvedPath, 'utf8');
+  } catch {
+    throw new HolodeckSceneLoadError({
+      code: HolodeckSceneLoadErrorCode.FILESYSTEM_ERROR,
+      message: `Failed to read body file: ${bodyFilePath}`,
+      path: 'response.bodyFile',
+      received: bodyFilePath,
+    });
+  }
+}

--- a/src/util/holodeck/readScene.ts
+++ b/src/util/holodeck/readScene.ts
@@ -1,0 +1,58 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { HolodeckSceneLoadError } from '../../holodeck/holodeck.error.ts';
+import { HolodeckSceneLoadErrorCode } from '../../type/holodeck/holodeck.error.ts';
+import type { HolodeckSceneDocument } from '../../type/holodeck/sceneDocument.ts';
+
+/**
+ * Lädt ein Holodeck-Szenen-Dokument aus dem Dateisystem.
+ *
+ * Der Dateiname wird aus dem Szenennamen gebildet:
+ *   <fixturesDir>/<sceneName>.scene.json
+ *
+ * Fehlerbehandlung:
+ * - Datei nicht gefunden → UNKNOWN_SCENE
+ * - Ungültiges JSON → SCHEMA_VIOLATION
+ *
+ * @param fixturesDir - Basisverzeichnis für Holodeck-Fixtures.
+ * @param sceneName - Name der Szene (ohne Dateiendung).
+ * @returns Das geparste Szenen-Dokument.
+ */
+export async function readSceneDocumentByName(
+  fixturesDir: string,
+  sceneName: string,
+): Promise<HolodeckSceneDocument> {
+  const sceneFilePath = join(fixturesDir, `${sceneName}.scene.json`);
+
+  let documentText: string;
+
+  try {
+    documentText = await readFile(sceneFilePath, 'utf8');
+  } catch (error) {
+    const isMissingFile =
+      typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      (error as { code?: string }).code === 'ENOENT';
+
+    if (isMissingFile) {
+      throw new HolodeckSceneLoadError({
+        code: HolodeckSceneLoadErrorCode.UNKNOWN_SCENE,
+        message: `Scene "${sceneName}" not found in ${fixturesDir}`,
+        path: 'scene',
+      });
+    }
+
+    throw error;
+  }
+
+  try {
+    return JSON.parse(documentText) as HolodeckSceneDocument;
+  } catch {
+    throw new HolodeckSceneLoadError({
+      code: HolodeckSceneLoadErrorCode.SCHEMA_VIOLATION,
+      message: `Scene "${sceneName}" contains invalid JSON`,
+      path: sceneFilePath,
+    });
+  }
+}

--- a/test/acceptance/feature/holodeck/start_and_stop.feature
+++ b/test/acceptance/feature/holodeck/start_and_stop.feature
@@ -1,4 +1,5 @@
 # language: de
+@holodeck
 Funktionalität: Holodeck starten, Szene laden und Antwort prüfen
   Um deterministische Tests zu ermöglichen,
   möchte ich ein Holodeck starten, eine vorbereitete Szene aktivieren
@@ -16,3 +17,12 @@ Funktionalität: Holodeck starten, Szene laden und Antwort prüfen
   Szenario: Cleanup: Holodeck stoppen nach dem Testlauf
     Wenn das Holodeck gestoppt wird
     Dann ist kein Holodeck mehr aktiv
+
+  @Wip
+  Szenario: Eine Holodeck-Szene liefert einen Response-Body aus einer HTML-Datei aus
+    Wenn die Holodeck-Szene "body-file-html" geladen wird
+    Und ich den Endpunkt "/test.html" über GET abrufe
+    Dann erwarte ich den HTTP-Statuscode 200
+    Und der Response-Body enthält "<h1>Schwarze Wegameise</h1>"
+    Und der Response-Body enthält "<h2 class=\"css-test\">Lasius niger</h2>"
+    Und das Holodeck gestoppt wird

--- a/test/acceptance/feature/setup/load-starfleet-directives.feature
+++ b/test/acceptance/feature/setup/load-starfleet-directives.feature
@@ -1,6 +1,5 @@
 # language: de
 @setup
-@Wip
 Funktionalität: Laden der Starfleet Directives
 
   Ziel:

--- a/test/acceptance/fixtures/holodeck/body-file-html.scene.json
+++ b/test/acceptance/fixtures/holodeck/body-file-html.scene.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "name": "body-file-html",
+  "variables": {
+    "title": {
+      "type": "string",
+      "default": "Schwarze Wegameise"
+    },
+    "scientificName": {
+      "type": "string",
+      "default": "Lasius niger"
+    }
+  },
+  "routes": [
+    {
+      "id": "body-file-html-route",
+      "request": {
+        "method": "GET",
+        "path": "/test.html"
+      },
+      "response": {
+        "statusCode": 200,
+        "headers": {
+          "Content-Type": "text/html"
+        },
+        "bodyFile": "html/test1.html"
+      },
+      "times": {
+        "unlimited": true
+      }
+    }
+  ]
+}

--- a/test/acceptance/fixtures/holodeck/html/test1.html
+++ b/test/acceptance/fixtures/holodeck/html/test1.html
@@ -1,0 +1,2 @@
+<h1>{{title}}</h1>
+<h2 class="css-test">{{scientificName}}</h2>

--- a/test/unit/holodeck/scene/bodyAndBodyFile.scene.ts
+++ b/test/unit/holodeck/scene/bodyAndBodyFile.scene.ts
@@ -1,0 +1,30 @@
+import type { HolodeckSceneDocument } from '../../../../src/type/holodeck/sceneDocument.ts';
+
+/**
+ * Szene „bodyAndBodyFile“ – absichtlich fehlerhaft.
+ *
+ * Diese Szene enthält gleichzeitig `response.body` und `response.bodyFile`.
+ * Sie dient der Prüfung, dass das JSON-Schema genau eine Body-Quelle erlaubt.
+ */
+export const bodyAndBodyFileScene: HolodeckSceneDocument = {
+  name: 'bodyAndBodyFile',
+  version: 1,
+  description:
+    'Invalid scene with response body and response body file at the same time.',
+  routes: [
+    {
+      id: 'body-and-body-file-route',
+      request: {
+        method: 'GET',
+        path: '/body-and-body-file',
+      },
+      response: {
+        statusCode: 200,
+        headers: { 'Content-Type': 'text/html' },
+        body: '<h1>Direkter Body</h1>',
+        bodyFile: 'html/test1.html',
+      },
+      times: { unlimited: true },
+    },
+  ],
+};

--- a/test/unit/holodeck/scene/bodyFile.scene.ts
+++ b/test/unit/holodeck/scene/bodyFile.scene.ts
@@ -1,0 +1,28 @@
+import type { HolodeckSceneDocument } from '../../../../src/type/holodeck/sceneDocument.ts';
+
+/**
+ * Szene „bodyFile“ – lädt den Response-Body aus einer Datei.
+ *
+ * Diese Szene prüft, ob `response.bodyFile` als Dateiverweis akzeptiert wird
+ * und der geladene Dateiinhalt später als `response.body` verwendet werden kann.
+ */
+export const bodyFileScene: HolodeckSceneDocument = {
+  name: 'bodyFile',
+  version: 1,
+  description: 'Scene with response body loaded from a fixture file.',
+  routes: [
+    {
+      id: 'body-file-route',
+      request: {
+        method: 'GET',
+        path: '/body-file',
+      },
+      response: {
+        statusCode: 200,
+        headers: { 'Content-Type': 'text/html' },
+        bodyFile: 'html/test1.html',
+      },
+      times: { unlimited: true },
+    },
+  ],
+};

--- a/test/unit/holodeck/scene/bodyFileWithTemplate.scene.ts
+++ b/test/unit/holodeck/scene/bodyFileWithTemplate.scene.ts
@@ -1,0 +1,35 @@
+import type { HolodeckSceneDocument } from '../../../../src/type/holodeck/sceneDocument.ts';
+
+/**
+ * Szene „bodyFileWithTemplate“ – lädt den Response-Body aus einer Datei mit Template-Variable.
+ *
+ * Diese Szene prüft, ob Variablen auch innerhalb eines per `bodyFile`
+ * geladenen Dateiinhalts gerendert werden.
+ */
+export const bodyFileWithTemplateScene: HolodeckSceneDocument = {
+  name: 'bodyFileWithTemplate',
+  version: 1,
+  description:
+    'Scene with response body loaded from a fixture file and rendered with variables.',
+  variables: {
+    title: {
+      type: 'string',
+      default: 'Schwarze Wegameise',
+    },
+  },
+  routes: [
+    {
+      id: 'body-file-template-route',
+      request: {
+        method: 'GET',
+        path: '/body-file-template',
+      },
+      response: {
+        statusCode: 200,
+        headers: { 'Content-Type': 'text/html' },
+        bodyFile: 'html/test-template.html',
+      },
+      times: { unlimited: true },
+    },
+  ],
+};

--- a/test/unit/holodeck/scene/withoutResponseBody.scene.ts
+++ b/test/unit/holodeck/scene/withoutResponseBody.scene.ts
@@ -1,0 +1,26 @@
+import type { HolodeckSceneDocument } from '../../../../src/type/holodeck/sceneDocument.ts';
+
+/**
+ * Szene „withoutResponseBody“ – absichtlich fehlerhaft.
+ *
+ * Diese Szene enthält weder `response.body` noch `response.bodyFile`.
+ * Sie dient der Prüfung, dass das JSON-Schema eine Response ohne Body-Quelle ablehnt.
+ */
+export const withoutResponseBodyScene: HolodeckSceneDocument = {
+  name: 'withoutResponseBody',
+  version: 1,
+  description: 'Invalid scene without response body or response body file.',
+  routes: [
+    {
+      id: 'without-response-body-route',
+      request: {
+        method: 'GET',
+        path: '/without-response-body',
+      },
+      response: {
+        statusCode: 200,
+      },
+      times: { unlimited: true },
+    },
+  ],
+};

--- a/test/unit/holodeck/sceneLoader.spec.ts
+++ b/test/unit/holodeck/sceneLoader.spec.ts
@@ -17,10 +17,14 @@ import { SceneLoader } from '../../../src/holodeck/sceneLoader.ts';
 import { HolodeckSceneLoadErrorCode } from '../../../src/type/holodeck/holodeck.error.ts';
 import type { HolodeckSceneDocument } from '../../../src/type/holodeck/sceneDocument.ts';
 import { badTemplateScene } from './scene/badTemplate.scene.ts';
+import { bodyAndBodyFileScene } from './scene/bodyAndBodyFile.scene.ts';
+import { bodyFileScene } from './scene/bodyFile.scene.ts';
+import { bodyFileWithTemplateScene } from './scene/bodyFileWithTemplate.scene.ts';
 import { happyScene } from './scene/happy.scene.ts';
 import { serverErrorScene } from './scene/serverError.scene.ts';
 import { timeScene } from './scene/time.scene.ts';
 import { timeoutScene } from './scene/timeout.scene.ts';
+import { withoutResponseBodyScene } from './scene/withoutResponseBody.scene.ts';
 
 describe('SceneLoader', () => {
   const nowDate = '2025-10-24T15:00:00.000Z' as const;
@@ -62,6 +66,68 @@ describe('SceneLoader', () => {
     it('setzt times korrekt auf { unlimited: true }', async () => {
       const loaded = await loader.loadScene('happy', {});
       expect(loaded.routes[0].times).toEqual({ unlimited: true });
+    });
+  });
+
+  describe('bodyFile', () => {
+    const now = new Date(nowDate);
+
+    it('lädt response.body aus bodyFile', async () => {
+      const loader = buildLoaderWithInMemoryScenes(
+        { bodyFile: bodyFileScene },
+        now,
+        {
+          'html/test1.html': '<h1>Testseite</h1>',
+        },
+      );
+
+      const loaded = await loader.loadScene('bodyFile', {});
+      const body = loaded.routes[0].response.body;
+
+      expect(body).toBe('<h1>Testseite</h1>');
+    });
+
+    it('rendert Templates im geladenen bodyFile-Inhalt', async () => {
+      const loader = buildLoaderWithInMemoryScenes(
+        { bodyFileWithTemplate: bodyFileWithTemplateScene },
+        now,
+        {
+          'html/test-template.html': '<h1>{{title}}</h1>',
+        },
+      );
+
+      const loaded = await loader.loadScene('bodyFileWithTemplate', {});
+      const body = loaded.routes[0].response.body;
+
+      expect(body).toBe('<h1>Schwarze Wegameise</h1>');
+    });
+
+    it('wirft schemaViolation bei unbekannter Template-Variable im bodyFile-Inhalt', async () => {
+      const loader = buildLoaderWithInMemoryScenes(
+        { bodyFile: bodyFileScene },
+        now,
+        {
+          'html/test1.html': '<h1>{{missingTitle}}</h1>',
+        },
+      );
+
+      await expect(loader.loadScene('bodyFile', {})).rejects.toMatchObject({
+        code: HolodeckSceneLoadErrorCode.SCHEMA_VIOLATION,
+        path: 'routes[0].response.body',
+      });
+    });
+
+    it('wirft filesystemError, wenn bodyFile nicht gelesen werden kann', async () => {
+      const loader = buildLoaderWithInMemoryScenes(
+        { bodyFile: bodyFileScene },
+        now,
+        {},
+      );
+
+      await expect(loader.loadScene('bodyFile', {})).rejects.toMatchObject({
+        code: HolodeckSceneLoadErrorCode.FILESYSTEM_ERROR,
+        path: 'routes[0].response.bodyFile',
+      });
     });
   });
 
@@ -179,12 +245,44 @@ describe('SceneLoader', () => {
         path: 'scene',
       });
     });
+
+    it('wirft schemaViolation, wenn response weder body noch bodyFile enthält', async () => {
+      const loader = buildLoaderWithInMemoryScenes(
+        { withoutResponseBody: withoutResponseBodyScene },
+        now,
+      );
+
+      await expect(
+        loader.loadScene('withoutResponseBody', {}),
+      ).rejects.toMatchObject({
+        code: HolodeckSceneLoadErrorCode.SCHEMA_VIOLATION,
+        path: 'scene',
+      });
+    });
+
+    it('wirft schemaViolation, wenn response body und bodyFile gleichzeitig enthält', async () => {
+      const loader = buildLoaderWithInMemoryScenes(
+        { bodyAndBodyFile: bodyAndBodyFileScene },
+        now,
+        {
+          'html/test1.html': '<h1>Testseite</h1>',
+        },
+      );
+
+      await expect(
+        loader.loadScene('bodyAndBodyFile', {}),
+      ).rejects.toMatchObject({
+        code: HolodeckSceneLoadErrorCode.SCHEMA_VIOLATION,
+        path: 'scene',
+      });
+    });
   });
 });
 
 function buildLoaderWithInMemoryScenes(
   sceneMap: Record<string, HolodeckSceneDocument>,
   fixedNow: Date,
+  bodyFileContentMap: Record<string, string | undefined> = {},
 ): SceneLoader {
   const ajv = new Ajv2020({
     allErrors: true,
@@ -204,6 +302,19 @@ function buildLoaderWithInMemoryScenes(
         });
       }
       return document;
+    },
+    readBodyFileContent: (bodyFilePath: string) => {
+      const content = bodyFileContentMap[bodyFilePath];
+
+      if (content === undefined) {
+        throw new HolodeckSceneLoadError({
+          code: HolodeckSceneLoadErrorCode.FILESYSTEM_ERROR,
+          message: `Body file ${bodyFilePath} not found`,
+          path: 'routes[0].response.bodyFile',
+        });
+      }
+
+      return content;
     },
     nowProvider: () => fixedNow,
     ajvInstance: ajv,


### PR DESCRIPTION
### 🚀 feat
- [0a3802d](../../commit/0a3802dca091bfb665083f94cd3cecf8d6511113) feat(holodeck): Unterstützung für bodyFile in Response implementieren
- [f051c05](../../commit/f051c0531bb1bbb2d8a44161bb3c63e57aed1621) feat(holodeck): Response-Body-Assertion-Schritt und bodyFile-Akzeptanztest ergänzt

### 🐛 fix
_none_

### ♻️ refactor
_none_

### 📝 docs
_none_

### ✅ test
_none_

### 🔧 ci
_none_

### 🧹 chore
_none_

### 🚧 wip
_none_

### 📦 Other
_none_